### PR TITLE
Add `Sysvar` trait

### DIFF
--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -15,6 +15,7 @@ pub mod log;
 pub mod program_error;
 pub mod pubkey;
 pub mod syscalls;
+pub mod sysvars;
 
 #[cfg(feature = "macro")]
 pub use pinocchio_macro::{declare_id, pubkey};

--- a/program/src/sysvars/mod.rs
+++ b/program/src/sysvars/mod.rs
@@ -1,0 +1,40 @@
+//! Provides access to system accounts.
+
+use crate::program_error::ProgramError;
+
+/// A type that holds sysvar data.
+pub trait Sysvar: Default + Sized {
+    /// Load the sysvar directly from the runtime.
+    ///
+    /// This is the preferred way to load a sysvar. Calling this method does not
+    /// incur any deserialization overhead, and does not require the sysvar
+    /// account to be passed to the program.
+    ///
+    /// Not all sysvars support this method. If not, it returns
+    /// [`ProgramError::UnsupportedSysvar`].
+    fn get() -> Result<Self, ProgramError> {
+        Err(ProgramError::UnsupportedSysvar)
+    }
+}
+
+/// Implements the [`Sysvar::get`] method for both SBF and host targets.
+#[macro_export]
+macro_rules! impl_sysvar_get {
+    ($syscall_name:ident) => {
+        fn get() -> Result<Self, $crate::program_error::ProgramError> {
+            let mut var = Self::default();
+            let var_addr = &mut var as *mut _ as *mut u8;
+
+            #[cfg(target_os = "solana")]
+            let result = unsafe { $crate::syscalls::$syscall_name(var_addr) };
+
+            #[cfg(not(target_os = "solana"))]
+            let result = core::hint::black_box(var_addr as *const _ as u64);
+
+            match result {
+                $crate::entrypoint::SUCCESS => Ok(var),
+                e => Err(e.into()),
+            }
+        }
+    };
+}


### PR DESCRIPTION
### Problem

While `pinocchio` currently includes syscalls to access sysvars, sysvar types are not present.

### Solution

This PR adds a `Sysvar` trait to represent sysvar data and provides a scaffolding macro to define getters.