### PR TITLE
Fix entrypoint compile error trait bound `AccountInfo: Copy` is not satisfied

### DIFF
--- a/sdk/src/entrypoint.rs
+++ b/sdk/src/entrypoint.rs
@@ -107,11 +107,12 @@ macro_rules! entrypoint {
     ( $process_instruction:ident, $maximum:expr ) => {
         #[no_mangle]
         pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
+            const UNINIT: std::mem::MaybeUninit<$crate::account_info::AccountInfo> =
+                std::mem::MaybeUninit::<$crate::account_info::AccountInfo>::uninit();
             // create an array of uninitialized account infos; it is safe to `assume_init` since
             // we are claiming that the array of `MaybeUninit` is initialized and `MaybeUninit` do
             // not require initialization
-            let mut accounts =
-                [std::mem::MaybeUninit::<$crate::account_info::AccountInfo>::uninit(); $maximum];
+            let mut accounts = [UNINIT; $maximum];
 
             let (program_id, count, instruction_data) =
                 $crate::entrypoint::deserialize::<$maximum>(input, &mut accounts);


### PR DESCRIPTION
Seems like `MaybeUninit` has changed in newer vers of rustc (using 1.81.0). Error msg pasted below for reference:

```
error[E0277]: the trait bound `AccountInfo: Copy` is not satisfied
 --> program/src/lib.rs:3:1
  |
3 | entrypoint!(process_instruction);
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `AccountInfo`, which is required by `MaybeUninit<AccountInfo>: Copy`
  |
  = note: required for `MaybeUninit<AccountInfo>` to implement `Copy`
  = note: the `Copy` trait is required because this value will be copied for each element of the array
  = note: this error originates in the macro `entrypoint` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider creating a new `const` item and initializing it with the result of the function call to be used in the repeat position
 --> /home/user/.cargo/git/checkouts/pinocchio-545b06e1308f21f1/bbfe860/sdk/src/entrypoint.rs:113:13
  |
11~             const ARRAY_REPEAT_VALUE: MaybeUninit<AccountInfo> = std::mem::MaybeUninit::<$crate::account_info::AccountInfo>::uninit();
11~             let mut accounts =
11~                 [ARRAY_REPEAT_VALUE; $maximum];
```