### PR TITLE
Make `AccountMeta.pubkey` public

### DIFF
--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -5,7 +5,7 @@ use crate::pubkey::Pubkey;
 #[derive(Debug, Clone)]
 pub struct AccountMeta {
     // Public key of the account.
-    pubkey: *const Pubkey,
+    pub pubkey: *const Pubkey,
 
     // Is the account writable?
     pub is_writable: bool,


### PR DESCRIPTION
As a lib consumer, there was no way to construct an `AccountMeta` struct previously because there were no constructor functions and AccountMeta.pubkey was private