### PR TITLE
Add types for CPI

### DIFF
--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -1,129 +1,14 @@
-use crate::pubkey::Pubkey;
+use crate::{account_info::AccountInfo, pubkey::Pubkey};
 
-/// An `AccountMeta`` as expected by `sol_invoke_signed_c`.
-#[repr(C)]
-#[derive(Debug, Clone)]
-pub struct AccountMeta {
-    // Public key of the account.
-    pubkey: *const Pubkey,
-
-    // Is the account writable?
-    pub is_writable: bool,
-
-    // Transaction was signed by this account's key?
-    pub is_signer: bool,
-}
-
-impl AccountMeta {
-    #[inline(always)]
-    pub fn pubkey(&self) -> &Pubkey {
-        unsafe { &*self.pubkey }
-    }
-}
-
-impl From<&crate::account_info::AccountInfo> for AccountMeta {
-    fn from(account: &crate::account_info::AccountInfo) -> Self {
-        AccountMeta {
-            pubkey: offset(account.raw, 8),
-            is_writable: account.is_writable(),
-            is_signer: account.is_signer(),
-        }
-    }
-}
-
-/// An `AccountInfo`` as expected by `sol_invoke_signed_c`.
-#[repr(C)]
-#[derive(Clone)]
-pub struct AccountInfo {
-    // Public key of the account.
-    pub key: *const Pubkey,
-
-    // Number of lamports owned by this account.
-    pub lamports: *const u64,
-
-    // Length of data in bytes.
-    pub data_len: u64,
-
-    // On-chain data within this account.
-    pub data: *const u8,
-
-    // Program that owns this account.
-    pub owner: *const Pubkey,
-
-    // The epoch at which this account will next owe rent.
-    pub rent_epoch: u64,
-
-    // Transaction was signed by this account's key?
-    pub is_signer: bool,
-
-    // Is the account writable?
-    pub is_writable: bool,
-
-    // This account's data contains a loaded program (and is now read-only).
-    pub executable: bool,
-}
-
-#[inline(always)]
-const fn offset<T, U>(ptr: *const T, offset: usize) -> *const U {
-    unsafe { (ptr as *const u8).add(offset) as *const U }
-}
-
-impl From<&crate::account_info::AccountInfo> for AccountInfo {
-    fn from(account: &crate::account_info::AccountInfo) -> Self {
-        AccountInfo {
-            key: offset(account.raw, 8),
-            lamports: offset(account.raw, 72),
-            data_len: account.data_len() as u64,
-            data: offset(account.raw, 88),
-            owner: offset(account.raw, 40),
-            rent_epoch: 0,
-            is_signer: account.is_signer(),
-            is_writable: account.is_writable(),
-            executable: account.executable(),
-        }
-    }
-}
-
-/// An `Instruction` as expected by `sol_invoke_signed_c`.
+/// Information about a CPI instruction.
 #[repr(C)]
 #[derive(Debug, PartialEq, Clone)]
-pub struct Instruction {
+pub struct Instruction<'a, 'b> {
     /// Public key of the program.
-    pub program_id: *const Pubkey,
-
-    /// Accounts expected by the program instruction.
-    pub accounts: *const AccountMeta,
-
-    /// Number of accounts expected by the program instruction.
-    pub accounts_len: u64,
+    pub program_id: &'a Pubkey,
 
     /// Data expected by the program instruction.
-    pub data: *const u8,
-
-    /// Length of the data expected by the program instruction.
-    pub data_len: u64,
-}
-
-/// A signer seed as expected by `sol_invoke_signed_c`.
-#[repr(C)]
-#[derive(Debug, PartialEq, Clone)]
-pub struct SignerSeed {
-    /// Seed bytes.
-    pub seed: *const u8,
-
-    /// Length of the seed bytes.
-    pub len: u64,
-}
-
-/// Signer as expected by `sol_invoke_signed_c`.
-#[repr(C)]
-#[derive(Debug, PartialEq, Clone)]
-pub struct Signer {
-    /// Seed bytes.
-    pub seeds: *const SignerSeed,
-
-    /// Number of signers.
-    pub len: u64,
+    pub data: &'b [u8],
 }
 
 /// Use to query and convey information about the sibling instruction components
@@ -136,4 +21,68 @@ pub struct ProcessedSiblingInstruction {
 
     /// Number of AccountMeta structures
     pub accounts_len: u64,
+}
+
+/// Describes a single account read or written by a program during instruction
+/// execution.
+///
+/// When constructing an [`Instruction`], a list of all accounts that may be
+/// read or written during the execution of that instruction must be supplied.
+/// Any account that may be mutated by the program during execution, either its
+/// data or metadata such as held lamports, must be writable.
+///
+/// Note that because the Solana runtime schedules parallel transaction
+/// execution around which accounts are writable, care should be taken that only
+/// accounts which actually may be mutated are specified as writable.
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct AccountMeta<'a> {
+    // Public key of the account.
+    pub pubkey: &'a Pubkey,
+
+    // Is the account writable?
+    pub is_writable: bool,
+
+    // Transaction was signed by this account's key?
+    pub is_signer: bool,
+}
+
+impl<'a> AccountMeta<'a> {
+    pub fn new(pubkey: &'a Pubkey, is_writable: bool, is_signer: bool) -> Self {
+        Self {
+            pubkey,
+            is_writable,
+            is_signer,
+        }
+    }
+
+    #[inline(always)]
+    pub fn readonly(pubkey: &'a Pubkey) -> Self {
+        Self::new(pubkey, false, false)
+    }
+
+    #[inline(always)]
+    pub fn writable(pubkey: &'a Pubkey) -> Self {
+        Self::new(pubkey, true, false)
+    }
+
+    #[inline(always)]
+    pub fn readonly_signer(pubkey: &'a Pubkey) -> Self {
+        Self::new(pubkey, false, true)
+    }
+
+    #[inline(always)]
+    pub fn writable_signer(pubkey: &'a Pubkey) -> Self {
+        Self::new(pubkey, true, true)
+    }
+}
+
+impl<'a> From<&'a AccountInfo> for AccountMeta<'a> {
+    fn from(account: &'a crate::account_info::AccountInfo) -> Self {
+        AccountMeta {
+            pubkey: account.key(),
+            is_writable: account.is_writable(),
+            is_signer: account.is_signer(),
+        }
+    }
 }

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -21,6 +21,111 @@ impl AccountMeta {
     }
 }
 
+impl From<&crate::account_info::AccountInfo> for AccountMeta {
+    fn from(account: &crate::account_info::AccountInfo) -> Self {
+        AccountMeta {
+            pubkey: offset(account.raw, 8),
+            is_writable: account.is_writable(),
+            is_signer: account.is_signer(),
+        }
+    }
+}
+
+/// An `AccountInfo`` as expected by `sol_invoke_signed_c`.
+#[repr(C)]
+#[derive(Clone)]
+pub struct AccountInfo {
+    // Public key of the account.
+    pub key: *const Pubkey,
+
+    // Number of lamports owned by this account.
+    pub lamports: *const u64,
+
+    // Length of data in bytes.
+    pub data_len: u64,
+
+    // On-chain data within this account.
+    pub data: *const u8,
+
+    // Program that owns this account.
+    pub owner: *const Pubkey,
+
+    // The epoch at which this account will next owe rent.
+    pub rent_epoch: u64,
+
+    // Transaction was signed by this account's key?
+    pub is_signer: bool,
+
+    // Is the account writable?
+    pub is_writable: bool,
+
+    // This account's data contains a loaded program (and is now read-only).
+    pub executable: bool,
+}
+
+#[inline(always)]
+const fn offset<T, U>(ptr: *const T, offset: usize) -> *const U {
+    unsafe { (ptr as *const u8).add(offset) as *const U }
+}
+
+impl From<&crate::account_info::AccountInfo> for AccountInfo {
+    fn from(account: &crate::account_info::AccountInfo) -> Self {
+        AccountInfo {
+            key: offset(account.raw, 8),
+            lamports: offset(account.raw, 72),
+            data_len: account.data_len() as u64,
+            data: offset(account.raw, 88),
+            owner: offset(account.raw, 40),
+            rent_epoch: 0,
+            is_signer: account.is_signer(),
+            is_writable: account.is_writable(),
+            executable: account.executable(),
+        }
+    }
+}
+
+/// An `Instruction` as expected by `sol_invoke_signed_c`.
+#[repr(C)]
+#[derive(Debug, PartialEq, Clone)]
+pub struct Instruction {
+    /// Public key of the program.
+    pub program_id: *const Pubkey,
+
+    /// Accounts expected by the program instruction.
+    pub accounts: *const AccountMeta,
+
+    /// Number of accounts expected by the program instruction.
+    pub accounts_len: u64,
+
+    /// Data expected by the program instruction.
+    pub data: *const u8,
+
+    /// Length of the data expected by the program instruction.
+    pub data_len: u64,
+}
+
+/// A signer seed as expected by `sol_invoke_signed_c`.
+#[repr(C)]
+#[derive(Debug, PartialEq, Clone)]
+pub struct SignerSeed {
+    /// Seed bytes.
+    pub seed: *const u8,
+
+    /// Length of the seed bytes.
+    pub len: u64,
+}
+
+/// Signer as expected by `sol_invoke_signed_c`.
+#[repr(C)]
+#[derive(Debug, PartialEq, Clone)]
+pub struct Signer {
+    /// Seed bytes.
+    pub seeds: *const SignerSeed,
+
+    /// Number of signers.
+    pub len: u64,
+}
+
 /// Use to query and convey information about the sibling instruction components
 /// when calling the `sol_get_processed_sibling_instruction` syscall.
 #[repr(C)]

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -1,15 +1,67 @@
+use std::marker::PhantomData;
+
 use crate::{account_info::AccountInfo, pubkey::Pubkey};
 
 /// Information about a CPI instruction.
 #[repr(C)]
-#[derive(Debug, PartialEq, Clone)]
-pub struct Instruction<'a, 'b> {
+#[derive(Debug, Clone)]
+pub struct Instruction<'a, 'b, 'c, 'd>
+where
+    'a: 'b,
+{
     /// Public key of the program.
-    pub program_id: &'a Pubkey,
+    pub program_id: &'c Pubkey,
 
     /// Data expected by the program instruction.
-    pub data: &'b [u8],
+    pub data: &'d [u8],
+
+    /// Metadata describing accounts that should be passed to the program.
+    pub accounts: &'b [AccountMeta<'a>],
 }
+
+/*
+/// An `Instruction` as expected by `sol_invoke_signed_c`.
+#[repr(C)]
+#[derive(Debug, PartialEq, Clone)]
+pub struct Instruction<'a, 'b, 'c, 'd> {
+    /// Public key of the program.
+    program_id: &'c Pubkey,
+
+    /// Accounts expected by the program instruction.
+    accounts: *const AccountMeta<'a>,
+
+    /// Number of accounts expected by the program instruction.
+    accounts_len: u64,
+
+    /// Data expected by the program instruction.
+    data: *const u8,
+
+    /// Length of the data expected by the program instruction.
+    data_len: u64,
+
+    _accounts: PhantomData<&'b [AccountMeta<'a>]>,
+
+    _data: PhantomData<&'d [u8]>,
+}
+
+impl<'a, 'b, 'c, 'd> Instruction<'a, 'b, 'c, 'd> {
+    pub fn new(
+        program_id: &'c Pubkey,
+        accounts: &'b [AccountMeta<'a>],
+        instruction_data: &'d [u8],
+    ) -> Self {
+        Self {
+            program_id,
+            accounts: accounts.as_ptr(),
+            accounts_len: accounts.len() as u64,
+            data: instruction_data.as_ptr(),
+            data_len: instruction_data.len() as u64,
+            _accounts: PhantomData::<&'b [AccountMeta<'a>]>,
+            _data: PhantomData::<&'d [u8]>,
+        }
+    }
+}
+*/
 
 /// Use to query and convey information about the sibling instruction components
 /// when calling the `sol_get_processed_sibling_instruction` syscall.
@@ -21,6 +73,69 @@ pub struct ProcessedSiblingInstruction {
 
     /// Number of AccountMeta structures
     pub accounts_len: u64,
+}
+
+/// An `Account` for CPI invocations.
+///
+/// This struct contains the same information as an [`AccountInfo`], but has
+/// the memory layout as expected by `sol_invoke_signed_c` syscall.
+#[repr(C)]
+#[derive(Clone)]
+pub struct Account<'a> {
+    // Public key of the account.
+    key: *const Pubkey,
+
+    // Number of lamports owned by this account.
+    lamports: *const u64,
+
+    // Length of data in bytes.
+    data_len: u64,
+
+    // On-chain data within this account.
+    data: *const u8,
+
+    // Program that owns this account.
+    owner: *const Pubkey,
+
+    // The epoch at which this account will next owe rent.
+    rent_epoch: u64,
+
+    // Transaction was signed by this account's key?
+    is_signer: bool,
+
+    // Is the account writable?
+    is_writable: bool,
+
+    // This account's data contains a loaded program (and is now read-only).
+    executable: bool,
+
+    /// The pointers to the `AccountInfo` data are only valid for as long as the
+    /// `&'a AccountInfo` lives. Instead of holding a reference to the actual `AccountInfo`,
+    /// which would increase the size of the type, we claim to hold a reference without
+    /// actually holding one using a `PhantomData<&'a AccountInfo>`.
+    _account_info: PhantomData<&'a AccountInfo>,
+}
+
+#[inline(always)]
+const fn offset<T, U>(ptr: *const T, offset: usize) -> *const U {
+    unsafe { (ptr as *const u8).add(offset) as *const U }
+}
+
+impl<'a> From<&'a AccountInfo> for Account<'a> {
+    fn from(account: &'a AccountInfo) -> Self {
+        Account {
+            key: offset(account.raw, 8),
+            lamports: offset(account.raw, 72),
+            data_len: account.data_len() as u64,
+            data: offset(account.raw, 88),
+            owner: offset(account.raw, 40),
+            rent_epoch: 0,
+            is_signer: account.is_signer(),
+            is_writable: account.is_writable(),
+            executable: account.executable(),
+            _account_info: PhantomData::<&'a AccountInfo>,
+        }
+    }
 }
 
 /// Describes a single account read or written by a program during instruction
@@ -40,10 +155,10 @@ pub struct AccountMeta<'a> {
     // Public key of the account.
     pub pubkey: &'a Pubkey,
 
-    // Is the account writable?
+    // Indicates whether the account is writable or not.
     pub is_writable: bool,
 
-    // Transaction was signed by this account's key?
+    // Indicates whether the account signed the instruction or not.
     pub is_signer: bool,
 }
 
@@ -79,10 +194,62 @@ impl<'a> AccountMeta<'a> {
 
 impl<'a> From<&'a AccountInfo> for AccountMeta<'a> {
     fn from(account: &'a crate::account_info::AccountInfo) -> Self {
-        AccountMeta {
-            pubkey: account.key(),
-            is_writable: account.is_writable(),
-            is_signer: account.is_signer(),
+        AccountMeta::new(account.key(), account.is_writable(), account.is_signer())
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct Seed<'a> {
+    /// Seed bytes.
+    pub(crate) seed: *const u8,
+
+    /// Length of the seed bytes.
+    len: u64,
+
+    /// The pointer to the seed bytes is only valid while the `&'a [u8]` lives. Instead
+    /// of holding a reference to the actual `[u8]`, which would increase the size of the
+    /// type, we claim to hold a reference without actually holding one using a
+    /// `PhantomData<&'a [u8]>`.
+    _bytes: PhantomData<&'a [u8]>,
+}
+
+impl<'a> From<&'a [u8]> for Seed<'a> {
+    fn from(value: &'a [u8]) -> Self {
+        Self {
+            seed: value.as_ptr(),
+            len: value.len() as u64,
+            _bytes: PhantomData::<&[u8]>,
+        }
+    }
+}
+
+/// Represents a [program derived address][pda] (PDA) signer controlled by the
+/// calling program.
+///
+/// [pda]: https://solana.com/docs/core/cpi#program-derived-addresses
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct Signer<'a, 'b> {
+    /// Signer seeds.
+    pub(crate) seeds: *const Seed<'a>,
+
+    /// Number of seeds.
+    pub(crate) len: u64,
+
+    /// The pointer to the seeds is only valid while the `&'b [Seed<'a>]` lives. Instead
+    /// of holding a reference to the actual `[Seed<'a>]`, which would increase the size
+    /// of the type, we claim to hold a reference without actually holding one using a
+    /// `PhantomData<&'b [Seed<'a>]>`.
+    _seeds: PhantomData<&'b [Seed<'a>]>,
+}
+
+impl<'a, 'b> From<&'b [Seed<'a>]> for Signer<'a, 'b> {
+    fn from(value: &'b [Seed<'a>]) -> Self {
+        Self {
+            seeds: value.as_ptr(),
+            len: value.len() as u64,
+            _seeds: PhantomData::<&'b [Seed<'a>]>,
         }
     }
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -12,6 +12,7 @@ pub mod account_info;
 pub mod entrypoint;
 pub mod instruction;
 pub mod log;
+pub mod program;
 pub mod program_error;
 pub mod pubkey;
 pub mod syscalls;

--- a/sdk/src/program.rs
+++ b/sdk/src/program.rs
@@ -1,0 +1,120 @@
+use crate::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey};
+
+/// An `AccountInfo` as expected by `sol_invoke_signed_c`.
+///
+/// DO NOT EXPOSE THIS STRUCT:
+///
+/// To ensure pointers are valid upon use, the scope of this struct should
+/// only be limited to the stack where sol_invoke_signed_c happens and then
+/// discarded immediately after.
+#[repr(C)]
+#[derive(Clone)]
+struct CAccountInfo {
+    // Public key of the account.
+    pub key: *const Pubkey,
+
+    // Number of lamports owned by this account.
+    pub lamports: *const u64,
+
+    // Length of data in bytes.
+    pub data_len: u64,
+
+    // On-chain data within this account.
+    pub data: *const u8,
+
+    // Program that owns this account.
+    pub owner: *const Pubkey,
+
+    // The epoch at which this account will next owe rent.
+    pub rent_epoch: u64,
+
+    // Transaction was signed by this account's key?
+    pub is_signer: bool,
+
+    // Is the account writable?
+    pub is_writable: bool,
+
+    // This account's data contains a loaded program (and is now read-only).
+    pub executable: bool,
+}
+
+#[inline(always)]
+const fn offset<T, U>(ptr: *const T, offset: usize) -> *const U {
+    unsafe { (ptr as *const u8).add(offset) as *const U }
+}
+
+impl From<&AccountInfo> for CAccountInfo {
+    fn from(account: &AccountInfo) -> Self {
+        CAccountInfo {
+            key: offset(account.raw, 8),
+            lamports: offset(account.raw, 72),
+            data_len: account.data_len() as u64,
+            data: offset(account.raw, 88),
+            owner: offset(account.raw, 40),
+            rent_epoch: 0,
+            is_signer: account.is_signer(),
+            is_writable: account.is_writable(),
+            executable: account.executable(),
+        }
+    }
+}
+
+/// An `Instruction` as expected by `sol_invoke_signed_c`.
+///
+/// DO NOT EXPOSE THIS STRUCT:
+///
+/// To ensure pointers are valid upon use, the scope of this struct should
+/// only be limited to the stack where sol_invoke_signed_c happens and then
+/// discarded immediately after.
+#[repr(C)]
+#[derive(Debug, PartialEq, Clone)]
+struct CInstruction<'a> {
+    /// Public key of the program.
+    pub program_id: *const Pubkey,
+
+    /// Accounts expected by the program instruction.
+    pub accounts: *const AccountMeta<'a>,
+
+    /// Number of accounts expected by the program instruction.
+    pub accounts_len: u64,
+
+    /// Data expected by the program instruction.
+    pub data: *const u8,
+
+    /// Length of the data expected by the program instruction.
+    pub data_len: u64,
+}
+
+/// A signer seed as expected by `sol_invoke_signed_c`.
+///
+/// DO NOT EXPOSE THIS STRUCT:
+///
+/// To ensure pointers are valid upon use, the scope of this struct should
+/// only be limited to the stack where sol_invoke_signed_c happens and then
+/// discarded immediately after.
+#[repr(C)]
+#[derive(Debug, PartialEq, Clone)]
+struct CSignerSeed {
+    /// Seed bytes.
+    pub seed: *const u8,
+
+    /// Length of the seed bytes.
+    pub len: u64,
+}
+
+/// Signer as expected by `sol_invoke_signed_c`.
+///
+/// DO NOT EXPOSE THIS STRUCT:
+///
+/// To ensure pointers are valid upon use, the scope of this struct should
+/// only be limited to the stack where sol_invoke_signed_c happens and then
+/// discarded immediately after.
+#[repr(C)]
+#[derive(Debug, PartialEq, Clone)]
+struct CSigner {
+    /// Seed bytes.
+    pub seeds: *const CSignerSeed,
+
+    /// Number of signers.
+    pub len: u64,
+}

--- a/sdk/src/program.rs
+++ b/sdk/src/program.rs
@@ -98,6 +98,22 @@ pub fn invoke_signed<const ACCOUNTS: usize>(
     Ok(())
 }
 
+/// Invoke a cross-program instruction but don't enforce Rust's aliasing rules.
+///
+/// This function does not check that [`Ref`]s within [`Account`]s are properly
+/// borrowable as described in the documentation for that function. Those checks
+/// consume CPU cycles that this function avoids.
+///
+/// # Safety
+///
+/// If any of the writable accounts passed to the callee contain data that is
+/// borrowed within the calling program, and that data is written to by the
+/// callee, then Rust's aliasing rules will be violated and cause undefined
+/// behavior.
+pub unsafe fn invoke_unchecked(instruction: &Instruction, accounts: &[Account]) {
+    invoke_signed_unchecked(instruction, accounts, &[])
+}
+
 /// Invoke a cross-program instruction with signatures but don't enforce Rust's
 /// aliasing rules.
 ///


### PR DESCRIPTION
This PR adds types needed to invoke other programs using `sol_invoke_signed_c` syscall.

Types defined on the `instruction` module:
* `Account`
* `AccountMeta`
* `Instruction`
* `Seed`
* `Signer`

These types are intended to be used by client code.

Types defined on the `program` module:
* `CInstruction` (private type)