### PR TITLE
Add `no_std` crate attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["sdk", "macro"]
+members = [
+    "sdk",
+    "macro"
+]

--- a/sdk/src/account_info.rs
+++ b/sdk/src/account_info.rs
@@ -1,8 +1,6 @@
 //! Data structures to represent account information.
 
-#![allow(clippy::missing_safety_doc)]
-
-use std::{ptr::NonNull, slice::from_raw_parts_mut};
+use core::{ptr::NonNull, slice::from_raw_parts_mut};
 
 use crate::{program_error::ProgramError, pubkey::Pubkey, syscalls::sol_memset_};
 
@@ -144,13 +142,13 @@ impl AccountInfo {
     #[allow(invalid_reference_casting)]
     pub fn assign(&self, new_owner: &Pubkey) {
         unsafe {
-            std::ptr::write_volatile(&(*self.raw).owner as *const _ as *mut Pubkey, *new_owner);
+            core::ptr::write_volatile(&(*self.raw).owner as *const _ as *mut Pubkey, *new_owner);
         }
     }
 
     /// Returns a read-only reference to the lamports in the account.
     ///
-    /// # SAFETY
+    /// # Safety
     ///
     /// This does not check or modify the 4-bit refcell. Useful when instruction
     /// has verified non-duplicate accounts.
@@ -160,7 +158,7 @@ impl AccountInfo {
 
     /// Returns a mutable reference to the lamports in the account.
     ///
-    /// # SAFETY
+    /// # Safety
     ///
     /// This does not check or modify the 4-bit refcell. Useful when instruction
     /// has verified non-duplicate accounts.
@@ -171,7 +169,7 @@ impl AccountInfo {
 
     /// Returns a read-only reference to the data in the account.
     ///
-    /// # SAFETY
+    /// # Safety
     ///
     /// This does not check or modify the 4-bit refcell. Useful when instruction
     /// has verified non-duplicate accounts.
@@ -181,7 +179,7 @@ impl AccountInfo {
 
     /// Returns a mutable reference to the data in the account.
     ///
-    /// # SAFETY
+    /// # Safety
     ///
     /// This does not check or modify the 4-bit refcell. Useful when instruction
     /// has verified non-duplicate accounts.
@@ -353,7 +351,7 @@ impl AccountInfo {
 
     /// Returns the memory address of the account data.
     fn data_ptr(&self) -> *mut u8 {
-        unsafe { (self.raw as *const _ as *mut u8).add(std::mem::size_of::<Account>()) }
+        unsafe { (self.raw as *const _ as *mut u8).add(core::mem::size_of::<Account>()) }
     }
 }
 

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{account_info::AccountInfo, pubkey::Pubkey};
 
@@ -18,50 +18,6 @@ where
     /// Metadata describing accounts that should be passed to the program.
     pub accounts: &'b [AccountMeta<'a>],
 }
-
-/*
-/// An `Instruction` as expected by `sol_invoke_signed_c`.
-#[repr(C)]
-#[derive(Debug, PartialEq, Clone)]
-pub struct Instruction<'a, 'b, 'c, 'd> {
-    /// Public key of the program.
-    program_id: &'c Pubkey,
-
-    /// Accounts expected by the program instruction.
-    accounts: *const AccountMeta<'a>,
-
-    /// Number of accounts expected by the program instruction.
-    accounts_len: u64,
-
-    /// Data expected by the program instruction.
-    data: *const u8,
-
-    /// Length of the data expected by the program instruction.
-    data_len: u64,
-
-    _accounts: PhantomData<&'b [AccountMeta<'a>]>,
-
-    _data: PhantomData<&'d [u8]>,
-}
-
-impl<'a, 'b, 'c, 'd> Instruction<'a, 'b, 'c, 'd> {
-    pub fn new(
-        program_id: &'c Pubkey,
-        accounts: &'b [AccountMeta<'a>],
-        instruction_data: &'d [u8],
-    ) -> Self {
-        Self {
-            program_id,
-            accounts: accounts.as_ptr(),
-            accounts_len: accounts.len() as u64,
-            data: instruction_data.as_ptr(),
-            data_len: instruction_data.len() as u64,
-            _accounts: PhantomData::<&'b [AccountMeta<'a>]>,
-            _data: PhantomData::<&'d [u8]>,
-        }
-    }
-}
-*/
 
 /// Use to query and convey information about the sibling instruction components
 /// when calling the `sol_get_processed_sibling_instruction` syscall.

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -7,6 +7,11 @@
 //!
 //! [`solana-sdk`]: https://docs.rs/solana-sdk/latest/solana_sdk/
 //! [`solana-program`]: https://docs.rs/solana-program/latest/solana_program/
+//!
+
+#![no_std]
+
+extern crate alloc;
 
 pub mod account_info;
 pub mod entrypoint;

--- a/sdk/src/program_error.rs
+++ b/sdk/src/program_error.rs
@@ -58,8 +58,8 @@ pub enum ProgramError {
     /// Provided seeds do not result in a valid address
     InvalidSeeds,
 
-    /// IO Error: `{0}`
-    BorshIoError(String),
+    /// IO Error
+    BorshIoError,
 
     /// An account does not have enough lamports to be rent-exempt
     AccountNotRentExempt,
@@ -147,7 +147,7 @@ impl From<u64> for ProgramError {
             ACCOUNT_BORROW_FAILED => Self::AccountBorrowFailed,
             MAX_SEED_LENGTH_EXCEEDED => Self::MaxSeedLengthExceeded,
             INVALID_SEEDS => Self::InvalidSeeds,
-            BORSH_IO_ERROR => Self::BorshIoError("Unknown".to_string()),
+            BORSH_IO_ERROR => Self::BorshIoError,
             ACCOUNT_NOT_RENT_EXEMPT => Self::AccountNotRentExempt,
             UNSUPPORTED_SYSVAR => Self::UnsupportedSysvar,
             ILLEGAL_OWNER => Self::IllegalOwner,
@@ -182,7 +182,7 @@ impl From<ProgramError> for u64 {
             ProgramError::AccountBorrowFailed => ACCOUNT_BORROW_FAILED,
             ProgramError::MaxSeedLengthExceeded => MAX_SEED_LENGTH_EXCEEDED,
             ProgramError::InvalidSeeds => INVALID_SEEDS,
-            ProgramError::BorshIoError(_) => BORSH_IO_ERROR,
+            ProgramError::BorshIoError => BORSH_IO_ERROR,
             ProgramError::AccountNotRentExempt => ACCOUNT_NOT_RENT_EXEMPT,
             ProgramError::UnsupportedSysvar => UNSUPPORTED_SYSVAR,
             ProgramError::IllegalOwner => ILLEGAL_OWNER,


### PR DESCRIPTION
Pinocchio currently does no allocations and therefore behaves as a `no_std` crate. This PR switch references to `std` by equivalent `core` ones and marks the crate as `no_std`.