### PR TITLE
Remove `macro` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,6 @@ dependencies = [
 [[package]]
 name = "pinocchio"
 version = "0.0.1"
-dependencies = [
- "pinocchio-macro",
-]
 
 [[package]]
 name = "pinocchio-macro"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -3,9 +3,3 @@ name = "pinocchio"
 description = "Create Solana programs with no strings attached"
 version = "0.0.1"
 edition = "2021"
-
-[features]
-macro = ["dep:pinocchio-macro"]
-
-[dependencies]
-pinocchio-macro = { version="^0", path="../macro", optional=true }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -22,6 +22,3 @@ pub mod program_error;
 pub mod pubkey;
 pub mod syscalls;
 pub mod sysvars;
-
-#[cfg(feature = "macro")]
-pub use pinocchio_macro::{declare_id, pubkey};


### PR DESCRIPTION
This PR removes the `macro` feature.

The idea is to add more functionalities on separate crates instead of using features.