### PR TITLE
Add return data functions

### DIFF
--- a/sdk/pinocchio/src/program.rs
+++ b/sdk/pinocchio/src/program.rs
@@ -1,6 +1,6 @@
 //! Cross-program invocation helpers.
 
-use core::mem::MaybeUninit;
+use core::{mem::MaybeUninit, ops::Deref};
 
 use crate::{
     account_info::AccountInfo,
@@ -171,4 +171,114 @@ pub unsafe fn invoke_signed_unchecked(
 
     #[cfg(not(target_os = "solana"))]
     core::hint::black_box((instruction, accounts, signers_seeds));
+}
+
+/// Maximum size that can be set using [`set_return_data`].
+pub const MAX_RETURN_DATA: usize = 1024;
+
+/// Set the running program's return data.
+///
+/// Return data is a dedicated per-transaction buffer for data passed
+/// from cross-program invoked programs back to their caller.
+///
+/// The maximum size of return data is [`MAX_RETURN_DATA`]. Return data is
+/// retrieved by the caller with [`get_return_data`].
+pub fn set_return_data(data: &[u8]) {
+    #[cfg(target_os = "solana")]
+    unsafe {
+        crate::syscalls::sol_set_return_data(data.as_ptr(), data.len() as u64)
+    };
+
+    #[cfg(not(target_os = "solana"))]
+    core::hint::black_box(data);
+}
+
+/// Get the return data from an invoked program.
+///
+/// For every transaction there is a single buffer with maximum length
+/// [`MAX_RETURN_DATA`], paired with a [`Pubkey`] representing the program ID of
+/// the program that most recently set the return data. Thus the return data is
+/// a global resource and care must be taken to ensure that it represents what
+/// is expected: called programs are free to set or not set the return data; and
+/// the return data may represent values set by programs multiple calls down the
+/// call stack, depending on the circumstances of transaction execution.
+///
+/// Return data is set by the callee with [`set_return_data`].
+///
+/// Return data is cleared before every CPI invocation &mdash; a program that
+/// has invoked no other programs can expect the return data to be `None`; if no
+/// return data was set by the previous CPI invocation, then this function
+/// returns `None`.
+///
+/// Return data is not cleared after returning from CPI invocations &mdash; a
+/// program that has called another program may retrieve return data that was
+/// not set by the called program, but instead set by a program further down the
+/// call stack; or, if a program calls itself recursively, it is possible that
+/// the return data was not set by the immediate call to that program, but by a
+/// subsequent recursive call to that program. Likewise, an external RPC caller
+/// may see return data that was not set by the program it is directly calling,
+/// but by a program that program called.
+///
+/// For more about return data see the [documentation for the return data proposal][rdp].
+///
+/// [rdp]: https://docs.solanalabs.com/proposals/return-data
+pub fn get_return_data() -> Option<ReturnData> {
+    #[cfg(target_os = "solana")]
+    {
+        let mut data = [0u8; MAX_RETURN_DATA];
+        let mut program_id = Pubkey::default();
+
+        let size = unsafe {
+            crate::syscalls::sol_get_return_data(
+                data.as_mut_ptr(),
+                data.len() as u64,
+                &mut program_id,
+            )
+        };
+
+        if size == 0 {
+            None
+        } else {
+            Some(ReturnData {
+                program_id,
+                data,
+                size: core::cmp::min(size as usize, MAX_RETURN_DATA),
+            })
+        }
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    core::hint::black_box(None)
+}
+
+/// Struct to hold the return data from an invoked program.
+pub struct ReturnData {
+    /// Program that most recently set the return data.
+    program_id: Pubkey,
+
+    /// Return data set by the program.
+    data: [u8; MAX_RETURN_DATA],
+
+    /// Length of the return data.
+    size: usize,
+}
+
+impl ReturnData {
+    /// Returns the program that most recently set the return data.
+    pub fn program_id(&self) -> &Pubkey {
+        &self.program_id
+    }
+
+    /// Return the data set by the program.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.data[..self.size]
+    }
+}
+
+impl Deref for ReturnData {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
 }


### PR DESCRIPTION
This PR adds the `set_return_data` and `get_return_data` functions. The return data is represented by the `ReturnData` type.