### PR TITLE
docs: Using Github callout in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pub fn process_instruction(
 }
 ```
 
-> ⚠️ **Note:**
+> [!NOTE]
 > You should use the types from the `pinocchio` crate instead of `solana-program`. If you need to invoke a different program, you will need to redefine its instruction builder to create an equivalent instruction data using `pinocchio` types.
 
 ## License


### PR DESCRIPTION
# Change

Used a Github callout in the README

<img width="893" alt="Screenshot 2024-10-12 at 7 48 56 AM" src="https://github.com/user-attachments/assets/ef3372c0-4018-48c4-bf39-4c978e7f60c4">

Can change it to the one you most prefer from the ones below:

![Screenshot 2024-10-12 at 7 49 42 AM](https://github.com/user-attachments/assets/daed7a70-421c-4248-a2c8-11d5bd4db3fa)


