### PR TITLE
token: Refactor state accounts

### DIFF
--- a/programs/token/src/state/account_state.rs
+++ b/programs/token/src/state/account_state.rs
@@ -1,6 +1,36 @@
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum AccountState {
+    /// Account is not yet initialized
     Uninitialized,
+
+    /// Account is initialized; the account owner and/or delegate may perform
+    /// permitted operations on this account
     Initialized,
+
+    /// Account has been frozen by the mint freeze authority. Neither the
+    /// account owner nor the delegate are able to perform operations on
+    /// this account.
     Frozen,
+}
+
+impl From<u8> for AccountState {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => AccountState::Uninitialized,
+            1 => AccountState::Initialized,
+            2 => AccountState::Frozen,
+            _ => panic!("invalid account state value: {value}"),
+        }
+    }
+}
+
+impl From<AccountState> for u8 {
+    fn from(value: AccountState) -> Self {
+        match value {
+            AccountState::Uninitialized => 0,
+            AccountState::Initialized => 1,
+            AccountState::Frozen => 2,
+        }
+    }
 }

--- a/programs/token/src/state/mint.rs
+++ b/programs/token/src/state/mint.rs
@@ -1,16 +1,44 @@
-use crate::ID;
-
 use pinocchio::{
     account_info::{AccountInfo, Ref},
     program_error::ProgramError,
     pubkey::Pubkey,
 };
-pub struct Mint(*const u8);
+
+use crate::ID;
+
+/// Mint data.
+#[repr(C)]
+pub struct Mint {
+    /// Indicates whether the mint authority is present or not.
+    mint_authority_flag: [u8; 4],
+
+    /// Optional authority used to mint new tokens. The mint authority may only
+    /// be provided during mint creation. If no mint authority is present
+    /// then the mint has a fixed supply and no further tokens may be
+    /// minted.
+    mint_authority: Pubkey,
+
+    /// Total supply of tokens.
+    supply: [u8; 8],
+
+    /// Number of base 10 digits to the right of the decimal place.
+    decimals: u8,
+
+    /// Is `true` if this structure has been initialized.
+    is_initialized: bool,
+
+    /// Indicates whether the freeze authority is present or not.
+    freeze_authority_flag: [u8; 4],
+
+    /// Optional authority to freeze token accounts.
+    freeze_authority: Pubkey,
+}
 
 impl Mint {
     pub const LEN: usize = 82;
 
-    /// Performs owner and length validation on `AccountInfo` and returns a `Ref<T>` for safe borrowing.
+    /// Performs owner and length validation on `AccountInfo` and returns a `Ref<Mint>` for
+    /// safe borrowing.
     pub fn from_account_info(account_info: &AccountInfo) -> Result<Ref<Mint>, ProgramError> {
         if account_info.data_len() != Self::LEN {
             return Err(ProgramError::InvalidAccountData);
@@ -24,12 +52,13 @@ impl Mint {
     }
 
     /// # Safety
-    /// Performs owner and length validation on `AccountInfo` but performs unchecked borrowing and
-    /// returns a `T` directly.
+    ///
+    /// Performs owner and length validation on `AccountInfo` but performs unchecked borrowing of
+    /// `Mint`.
     #[inline(always)]
     pub unsafe fn from_account_info_unchecked(
         account_info: &AccountInfo,
-    ) -> Result<Mint, ProgramError> {
+    ) -> Result<&Self, ProgramError> {
         if account_info.data_len() != Self::LEN {
             return Err(ProgramError::InvalidAccountData);
         }
@@ -40,18 +69,18 @@ impl Mint {
     }
 
     /// # Safety
-    /// Constructs a `T` directly from a byte slice. The caller must ensure that `bytes` contains a
-    /// valid representation of `T`.
-    pub unsafe fn from_bytes(bytes: &[u8]) -> Self {
-        Self(bytes.as_ptr())
+    ///
+    /// The caller must ensure that `bytes` contains a valid representation of `Mint`.
+    pub unsafe fn from_bytes(bytes: &[u8]) -> &Self {
+        &*(bytes.as_ptr() as *const Mint)
     }
 
     #[inline(always)]
     pub fn has_mint_authority(&self) -> bool {
-        unsafe { *(self.0 as *const bool) }
+        self.mint_authority_flag[0] == 1
     }
 
-    pub fn mint_authority(&self) -> Option<Pubkey> {
+    pub fn mint_authority(&self) -> Option<&Pubkey> {
         if self.has_mint_authority() {
             Some(self.mint_authority_unchecked())
         } else {
@@ -59,30 +88,31 @@ impl Mint {
         }
     }
 
-    /// Use this when you know the account will have a mint authority and you want to skip the Option check.
+    /// Use this when you know the account will have a mint authority and you want
+    /// to skip the `Option` check.
     #[inline(always)]
-    pub fn mint_authority_unchecked(&self) -> Pubkey {
-        unsafe { *(self.0.add(4) as *const Pubkey) }
+    pub fn mint_authority_unchecked(&self) -> &Pubkey {
+        &self.mint_authority
     }
 
     pub fn supply(&self) -> u64 {
-        unsafe { core::ptr::read_unaligned(self.0.add(36) as *const u64) }
+        unsafe { core::ptr::read_unaligned(self.supply.as_ptr() as *const u64) }
     }
 
     pub fn decimals(&self) -> u8 {
-        unsafe { *self.0.add(44) }
+        self.decimals
     }
 
     pub fn is_initialized(&self) -> bool {
-        unsafe { *(self.0.add(45) as *const bool) }
+        self.is_initialized
     }
 
     #[inline(always)]
     pub fn has_freeze_authority(&self) -> bool {
-        unsafe { *(self.0.add(46) as *const bool) }
+        self.freeze_authority_flag[0] == 1
     }
 
-    pub fn freeze_authority(&self) -> Option<Pubkey> {
+    pub fn freeze_authority(&self) -> Option<&Pubkey> {
         if self.has_freeze_authority() {
             Some(self.freeze_authority_unchecked())
         } else {
@@ -90,9 +120,10 @@ impl Mint {
         }
     }
 
-    /// Use this when you know the account will have a freeze authority and you want to skip the Option check.
+    /// Use this when you know the account will have a freeze authority and you want
+    /// to skip the `Option` check.
     #[inline(always)]
-    pub fn freeze_authority_unchecked(&self) -> Pubkey {
-        unsafe { *(self.0.add(50) as *const Pubkey) }
+    pub fn freeze_authority_unchecked(&self) -> &Pubkey {
+        &self.freeze_authority
     }
 }


### PR DESCRIPTION
### Problem

Currently the `from_account_info` helpers on the token state accounts are not performing a valid conversion.

### Solution

Refactor the state accounts representation so it is possible to create a reference to an account type directly from the account data.