### PR TITLE
A close macro implementation for AccountInfo

### DIFF
--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -378,6 +378,26 @@ impl AccountInfo {
         Ok(())
     }
 
+    /// Zero out the the account's data_len, lamports and owner fields, effectively
+    /// closing the account.
+    ///
+    /// Note: This doesn't protect against future reinitialization of the account 
+    /// since the account_data will need to be zeroed out as well. Or if the attacker
+    /// has access to the keypair of the account that we're trying to close, they can
+    /// just add the lenght, lamports and owner back before the data is wiped out from
+    /// the ledger.
+    /// 
+    /// Note: This works because the 48 bytes before the account data are:
+    /// - 8 bytes for the data_len
+    /// - 8 bytes for the lamports
+    /// - 32 bytes for the owner
+    ///
+    /// # Safety
+    ///
+    /// This method makes assumptions about the layout and location of memory
+    /// referenced by `AccountInfo` fields. It should only be called for
+    /// instances of `AccountInfo` that were created by the runtime and received
+    /// in the `process_instruction` entrypoint of a program.
     #[inline(always)]
     pub fn close(&self) {
         unsafe {
@@ -385,13 +405,31 @@ impl AccountInfo {
         }
     }
 
-    /// todo
+    /// Zero out the the account's data_len, lamports and owner fields, effectively
+    /// closing the account.
+    ///
+    /// Note: This doesn't protect against future reinitialization of the account 
+    /// since the account_data will need to be zeroed out as well. Or if the attacker
+    /// has access to the keypair of the account that we're trying to close, they can
+    /// just add the lenght, lamports and owner back before the data is wiped out from
+    /// the ledger.
+    /// 
+    /// Note: This works because the 48 bytes before the account data are:
+    /// - 8 bytes for the data_len
+    /// - 8 bytes for the lamports
+    /// - 32 bytes for the owner
     ///
     /// # Safety
     ///
-    /// todo
+    /// This method makes assumptions about the layout and location of memory
+    /// referenced by `AccountInfo` fields. It should only be called for
+    /// instances of `AccountInfo` that were created by the runtime and received
+    /// in the `process_instruction` entrypoint of a program.
+    /// 
+    /// This method set the variable as 0 making sure that we're actually zeroing out
+    /// the bytes.
     #[inline(always)]
-    pub unsafe fn based_close(&self) {
+    pub unsafe fn optimized_close(&self) {
         #[cfg(target_os = "solana")]
         unsafe {
             let var = 0u64;

--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -381,12 +381,12 @@ impl AccountInfo {
     /// Zero out the the account's data_len, lamports and owner fields, effectively
     /// closing the account.
     ///
-    /// Note: This doesn't protect against future reinitialization of the account 
+    /// Note: This doesn't protect against future reinitialization of the account
     /// since the account_data will need to be zeroed out as well. Or if the attacker
     /// has access to the keypair of the account that we're trying to close, they can
     /// just add the lenght, lamports and owner back before the data is wiped out from
     /// the ledger.
-    /// 
+    ///
     /// Note: This works because the 48 bytes before the account data are:
     /// - 8 bytes for the data_len
     /// - 8 bytes for the lamports
@@ -408,12 +408,12 @@ impl AccountInfo {
     /// Zero out the the account's data_len, lamports and owner fields, effectively
     /// closing the account.
     ///
-    /// Note: This doesn't protect against future reinitialization of the account 
+    /// Note: This doesn't protect against future reinitialization of the account
     /// since the account_data will need to be zeroed out as well. Or if the attacker
     /// has access to the keypair of the account that we're trying to close, they can
     /// just add the lenght, lamports and owner back before the data is wiped out from
     /// the ledger.
-    /// 
+    ///
     /// Note: This works because the 48 bytes before the account data are:
     /// - 8 bytes for the data_len
     /// - 8 bytes for the lamports
@@ -425,7 +425,7 @@ impl AccountInfo {
     /// referenced by `AccountInfo` fields. It should only be called for
     /// instances of `AccountInfo` that were created by the runtime and received
     /// in the `process_instruction` entrypoint of a program.
-    /// 
+    ///
     /// This method set the variable as 0 making sure that we're actually zeroing out
     /// the bytes.
     #[inline(always)]

--- a/sdk/pinocchio/src/lib.rs
+++ b/sdk/pinocchio/src/lib.rs
@@ -9,7 +9,7 @@
 //! [`solana-program`]: https://docs.rs/solana-program/latest/solana_program/
 
 #![no_std]
-#![cfg_attr(target_os="solana", feature(asm_experimental_arch, asm_const))]
+#![cfg_attr(target_os = "solana", feature(asm_experimental_arch, asm_const))]
 
 pub mod account_info;
 pub mod entrypoint;

--- a/sdk/pinocchio/src/lib.rs
+++ b/sdk/pinocchio/src/lib.rs
@@ -9,6 +9,7 @@
 //! [`solana-program`]: https://docs.rs/solana-program/latest/solana_program/
 
 #![no_std]
+#![cfg_attr(target_os="solana", feature(asm_experimental_arch, asm_const))]
 
 pub mod account_info;
 pub mod entrypoint;


### PR DESCRIPTION
PRd this macro implementation invented by @deanmlittle (known as `based_close`) in the Pinocchio AccountInfo implementation to use it more easily.

I added 2 different function + docs:
- `.close()`: the implementation with pointer of the underlying idea
- `.optimized_close()`: the implementation with assembly of the underlying idea (marked the implementation as unsafe function since it uses `asm_experimental_arch`

Some data about the CU usage: 
- `.close()`: takes 60 CUs
- `.optimized_close()`: takes 7 CUs

**Edit**: now close has 7CUs as well (thanks to @febo's comment) and `optimized_close()` is now called `assembly_close()`