### PR TITLE
Fixed Realloc Macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ use pinocchio::{
   account_info::AccountInfo,
   entrypoint,
   msg,
-  ProgramResult
+  ProgramResult,
   pubkey::Pubkey
 };
 

--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -377,8 +377,13 @@ impl AccountInfo {
         }
 
         #[cfg(not(target_os = "solana"))]
-        {
-            core::hint::black_box(zero_init);
+        if zero_init {
+            let len_increase = new_len.saturating_sub(current_len);
+            if len_increase > 0 {
+                unsafe {
+                    core::ptr::write_bytes(data.as_mut_ptr().add(current_len), 0, len_increase);
+                }
+            }
         }
 
         Ok(())

--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -1,5 +1,4 @@
 //! Data structures to represent account information.
-
 use core::{marker::PhantomData, mem::ManuallyDrop, ptr::NonNull, slice::from_raw_parts_mut};
 
 use crate::{program_error::ProgramError, pubkey::Pubkey, syscalls::sol_memset_};
@@ -363,6 +362,7 @@ impl AccountInfo {
             data.value = NonNull::from(from_raw_parts_mut(data_ptr, new_len));
         }
 
+        #[cfg(target_os = "solana")]
         if zero_init {
             let len_increase = new_len.saturating_sub(current_len);
             if len_increase > 0 {
@@ -374,6 +374,11 @@ impl AccountInfo {
                     );
                 }
             }
+        }
+
+        #[cfg(not(target_os = "solana"))]
+        {
+            core::hint::black_box(zero_init);
         }
 
         Ok(())

--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -381,16 +381,6 @@ impl AccountInfo {
             }
         }
 
-        #[cfg(not(target_os = "solana"))]
-        if zero_init {
-            let len_increase = new_len.saturating_sub(current_len);
-            if len_increase > 0 {
-                unsafe {
-                    core::ptr::write_bytes(data.as_mut_ptr().add(current_len), 0, len_increase);
-                }
-            }
-        }
-
         Ok(())
     }
 


### PR DESCRIPTION
Realloc was broken when trying to use it in a program with the following error: 
```
= note: Undefined symbols for architecture arm64:
"_sol_memset_", referenced from:
    pinocchio::account_info::AccountInfo::realloc::h7b767197c3b52406 in libpinocchio-b1a74aa98b057767.rlib(pinocchio-b1a74aa98b057767.8lu0acfwt9wrlqb8ft0k7wz4l.rcgu.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

By specifying that it needs to target Solana as os this problem is not there anymore