### PR TITLE
rent: Rent exempt calculation improvement

### DIFF
--- a/sdk/pinocchio/src/sysvars/rent.rs
+++ b/sdk/pinocchio/src/sysvars/rent.rs
@@ -53,17 +53,17 @@ pub struct Rent {
     pub burn_percent: u8,
 }
 
-/// Calculates the rent for a given number of bytes and duration
-///
-/// # Arguments
-///
-/// * `bytes` - The number of bytes to calculate rent for
-/// * `years` - The number of years to calculate rent for
-///
-/// # Returns
-///
-/// The total rent in lamports
 impl Rent {
+    /// Return a `Rent` from the given bytes.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `bytes` contains a valid representation of `Rent`.
+    #[inline]
+    pub unsafe fn from_bytes(bytes: &[u8]) -> &Self {
+        &*(bytes.as_ptr() as *const Rent)
+    }
+
     /// Calculate how much rent to burn from the collected rent.
     ///
     /// The first value returned is the amount burned. The second is the amount


### PR DESCRIPTION
### Problem

Rent exempt calculation involves operations with `f64` values, which are expensive to do on-chain as described in this [SIMD](https://github.com/solana-foundation/solana-improvement-documents/pull/194).

### Solution

We can avoid `f64` operations when the rent exempt threshold is known to not have a fractional part. This PR checks whether the current rent exempt is equal to the default one (`2.0`) or not; when it is, the calculation of rent exempt is performed as `u64`.