### PR TITLE
Add precision formatting

### DIFF
--- a/sdk/log/crate/src/lib.rs
+++ b/sdk/log/crate/src/lib.rs
@@ -38,7 +38,7 @@ pub use pinocchio_log_macro::*;
 
 #[cfg(test)]
 mod tests {
-    use crate::logger::Logger;
+    use crate::logger::{Argument, Logger};
 
     #[test]
     fn test_logger() {
@@ -109,5 +109,28 @@ mod tests {
         logger.append(-200_000_000);
 
         assert!(&*logger == "-200@".as_bytes());
+    }
+
+    #[test]
+    fn test_logger_with_args() {
+        let mut logger = Logger::<10>::default();
+
+        logger.append_with_args(200_000_000u64, &[Argument::Precision(2)]);
+        assert!(&*logger == "2000000.00".as_bytes());
+
+        logger.clear();
+
+        logger.append_with_args(2_000_000_000u64, &[Argument::Precision(2)]);
+        assert!(&*logger == "20000000.@".as_bytes());
+
+        logger.clear();
+
+        logger.append_with_args(2_000_000_000u64, &[Argument::Precision(5)]);
+        assert!(&*logger == "20000.000@".as_bytes());
+
+        logger.clear();
+
+        logger.append_with_args(2_000_000_000u64, &[Argument::Precision(10)]);
+        assert!(&*logger == "0.2000000@".as_bytes());
     }
 }

--- a/sdk/log/crate/src/lib.rs
+++ b/sdk/log/crate/src/lib.rs
@@ -132,5 +132,15 @@ mod tests {
 
         logger.append_with_args(2_000_000_000u64, &[Argument::Precision(10)]);
         assert!(&*logger == "0.2000000@".as_bytes());
+
+        logger.clear();
+
+        logger.append_with_args(2u64, &[Argument::Precision(6)]);
+        assert!(&*logger == "0.000002".as_bytes());
+
+        logger.clear();
+
+        logger.append_with_args(2u64, &[Argument::Precision(9)]);
+        assert!(&*logger == "0.0000000@".as_bytes());
     }
 }

--- a/sdk/log/crate/src/lib.rs
+++ b/sdk/log/crate/src/lib.rs
@@ -142,5 +142,15 @@ mod tests {
 
         logger.append_with_args(2u64, &[Argument::Precision(9)]);
         assert!(&*logger == "0.0000000@".as_bytes());
+
+        logger.clear();
+
+        logger.append_with_args(-2000000i32, &[Argument::Precision(6)]);
+        assert!(&*logger == "-2.000000".as_bytes());
+
+        logger.clear();
+
+        logger.append_with_args(-2i64, &[Argument::Precision(9)]);
+        assert!(&*logger == "-0.000000@".as_bytes());
     }
 }

--- a/sdk/log/crate/src/lib.rs
+++ b/sdk/log/crate/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! # Example
 //!
-//! Creating a `Logger` with a buffer size of 100 bytes, and appending a string and an
+//! Creating a `Logger` with a buffer size of `100` bytes, and appending a string and an
 //! `u64` value:
 //!
 //! ```
@@ -26,6 +26,20 @@
 //! logger.clear();
 //!
 //! logger.append(&["Hello ", "world!"]);
+//! logger.log();
+//! ```
+//!
+//! It also support adding precision to numeric types:
+//!
+//! ```
+//! use pinocchio_log::logger::{Argument, Logger};
+//!
+//! let mut logger = Logger::<100>::default();
+//!
+//! let lamports = 1_000_000_000u64;
+//!
+//! logger.append("balance (SOL)=");
+//! logger.append(lamports, &[Argument::Precision(9)]);
 //! logger.log();
 //! ```
 

--- a/sdk/pinocchio/Cargo.toml
+++ b/sdk/pinocchio/Cargo.toml
@@ -12,3 +12,6 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(target_os, values("solana"))',
     'cfg(target_feature, values("static-syscalls"))',
 ] }
+
+[features]
+std = []

--- a/sdk/pinocchio/src/entrypoint.rs
+++ b/sdk/pinocchio/src/entrypoint.rs
@@ -208,8 +208,12 @@ macro_rules! custom_panic_default {
         #[cfg(all(not(feature = "custom-panic"), target_os = "solana"))]
         #[no_mangle]
         fn custom_panic(info: &core::panic::PanicInfo<'_>) {
-            // Full panic reporting.
+            // Panic reporting.
+            #[cfg(feature = "std")]
             $crate::msg!("{}", info);
+
+            #[cfg(not(feature = "std"))]
+            $crate::msg!("panic occurred");
         }
     };
 }

--- a/sdk/pinocchio/src/log.rs
+++ b/sdk/pinocchio/src/log.rs
@@ -36,6 +36,15 @@
 use crate::{account_info::AccountInfo, pubkey::log};
 
 #[macro_export]
+#[cfg(not(feature = "std"))]
+macro_rules! msg {
+    ($msg:expr) => {
+        $crate::log::sol_log($msg)
+    };
+}
+
+#[macro_export]
+#[cfg(feature = "std")]
 macro_rules! msg {
     ($msg:expr) => {
         $crate::log::sol_log($msg)
@@ -89,6 +98,7 @@ pub fn sol_log_slice(slice: &[u8]) {
 ///
 /// - `accounts` - A slice of [`AccountInfo`].
 /// - `data` - The instruction data.
+#[cfg(feature = "std")]
 pub fn sol_log_params(accounts: &[AccountInfo], data: &[u8]) {
     for (i, account) in accounts.iter().enumerate() {
         msg!("AccountInfo");


### PR DESCRIPTION
### Problem

Currently the `Logger` does not support formatting attributes. In particular, there is no way to format numeric values to take into account the decimals.

### Solution

Add an `Attribute` enum to specify optional formatting attributes. At the moment, only one variant is implemented: `Precision(u8)`.

Note that the `log!` macro does not support specifying the precision, this will be added in a separate PR.

### Usage

```rust
use pinocchio_log::logger::{Attribute, Logger};

let lamports = 1_000_000_000;
let mut logger = Logger::<100>::default();
logger.append("SOL: ");
logger.append_with_args(amount, &[Argument::Precision(9)]);
logger.log()
```