### PR TITLE
Add precision formatting to `log!` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "five8_const"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +25,12 @@ name = "five8_core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a72055cd9cffc40c9f75f1e5810c80559e158796cf2202292ce4745889588"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "pinocchio"
@@ -33,6 +48,7 @@ name = "pinocchio-log-macro"
 version = "0.1.0"
 dependencies = [
  "quote",
+ "regex",
  "syn",
 ]
 
@@ -77,6 +93,35 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "syn"

--- a/sdk/log/README.md
+++ b/sdk/log/README.md
@@ -1,6 +1,12 @@
-# <img height="70" alt="pinocchio-log" src="https://github.com/user-attachments/assets/caee2220-d11b-4b6a-aefd-6f6bd9815b73"/>
-
-Lightweight log utility for Solana programs.
+<p align="center">
+ <img width="200" alt="pinocchio-log" src="https://github.com/user-attachments/assets/00704646-7e8d-4dfc-bfbb-4ce18d528480"/>
+</p>
+<p align="center">
+ Lightweight log utility for Solana programs.
+</p>
+<p align="center">
+  <a href="https://crates.io/crates/pinocchio-log"><img src="https://img.shields.io/crates/v/pinocchio-log?logo=rust" /></a>
+</p>
 
 ## Overview
 

--- a/sdk/log/README.md
+++ b/sdk/log/README.md
@@ -2,6 +2,9 @@
  <img width="200" alt="pinocchio-log" src="https://github.com/user-attachments/assets/00704646-7e8d-4dfc-bfbb-4ce18d528480"/>
 </p>
 <p align="center">
+ <code>pinocchio-log</code>
+</p>
+<p align="center">
  Lightweight log utility for Solana programs.
 </p>
 <p align="center">

--- a/sdk/log/README.md
+++ b/sdk/log/README.md
@@ -17,14 +17,17 @@ While the cost related to (1) is *fixed*, in the sense that it does not change w
 This crate defines a lightweight `Logger` type to format log messages and a companion `log!` macro. The logger is a fixed size buffer that can be used to format log messages before sending them to the log output. Any type that implements the `Log` trait can be appended to the logger. Additionally, the logger can the dereferenced to a `&[u8]` slice, which can be used for other purposes &mdash; e.g., it can be used to create `&str` to be stored on an account or return data of programs.
 
 Below is a sample of the improvements observed when formatting log messages, measured in terms of compute units (CU):
-| Ouput message                      | `log!` | `msg!`       | Improvement (%) |
-|------------------------------------|--------|--------------|-----------------|
-| `"Hello world!"`                   | 104    | 104          | -               |
-| `"lamports={}"` + `u64`            | 286    | 625 (+339)   | 55%             |
-| `"{}"` + `[&str; 2]`               | 119    | 1610 (+1491) | 93%             |
-| `"{}"` + `[u64; 2]`                | 483    | 1154 (+671)  | 49%             |
-| `"lamports={}"` + `i64`            | 299    | 659 (+360)   | 55%             |
-| `"{}"` + `[u8; 32]` (pubkey bytes) | 2783   | 8397 (+5614) | 67%             |
+| Ouput message                      | `log!` | `msg!`          | Improvement (%) |
+|------------------------------------|--------|-----------------|-----------------|
+| `"Hello world!"`                   | 104    | 104             | -               |
+| `"lamports={}"` + `u64`            | 286    | 625 (+339)      | 55%             |
+| `"{}"` + `[&str; 2]`               | 119    | 1610 (+1491)    | 93%             |
+| `"{}"` + `[u64; 2]`                | 483    | 1154 (+671)     | 49%             |
+| `"lamports={}"` + `i64`            | 299    | 659 (+360)      | 55%             |
+| `"{}"` + `[u8; 32]` (pubkey bytes) | 2783   | 8397 (+5614)    | 67%             |
+| `"lamports={:.9}"` + `u64`         | 438    | 2656 (+2218)`*` | 84%             |
+
+`*` For `msg!`, the value is logged as a `f64` otherwise the precision formatting is ignored.
 
 > Note: The improvement in CU is accumulative, meaning that if you are logging multiple `u64` values, there will be a 40% improvement per formatted `u64` value.
 
@@ -58,8 +61,10 @@ logger.log();
  ```rust
 use pinocchio_log::log
 
-let amount = 1_000_000_000;
-log!("transfer amount: {}", amount);
+let lamports = 1_000_000_000;
+log!("transfer amount: {}", lamports);
+// Logs the transfer amount in SOL (lamports with 9 decimal digits)
+log!("transfer amount (SOL): {:.9}", lamports);
 ```
 
 Since the formatting routine does not perform additional allocations, the `Logger` type has a fixed size specified on its creation. When using the `log!` macro, it is also possible to specify the size of the logger buffer:
@@ -67,8 +72,8 @@ Since the formatting routine does not perform additional allocations, the `Logge
 ```rust
 use pinocchio_log::log
 
-let amount = 1_000_000_000;
-log!(100, "transfer amount: {}", amount);
+let lamports = 1_000_000_000;
+log!(50, "transfer amount: {}", lamports);
 ```
 
 It is also possible to dereference the `Logger` into a `&[u8]` slice and use the result for other purposes:
@@ -83,7 +88,7 @@ logger.append(amount);
 let prize_title = core::str::from_utf8(&logger)?;
 ```
 
-When using the `Logger` directly, it is possible to include a precision formatting for number values:
+When using the `Logger` directly, it is possible to include a precision formatting for numeric values:
 ```rust
 use pinocchio_log::logger::{Attribute, Logger};
 
@@ -96,7 +101,7 @@ logger.log()
 
 ## Limitations
 
-Currently the `log!` macro does not offer extra formatting options apart from the placeholder "`{}`" for argument values.
+Currently the `log!` macro only offers limited formatting options. Apart from the placeholder `"{}"` for argument values, it is possible to specify the number of decimals digits for numeric values.
 
 ## License
 

--- a/sdk/log/macro/Cargo.toml
+++ b/sdk/log/macro/Cargo.toml
@@ -12,4 +12,5 @@ proc-macro = true
 
 [dependencies]
 quote = "^1.0"
+regex = "^1"
 syn = { version = "^1.0", features = ["extra-traits", "full"] }

--- a/sdk/log/macro/src/lib.rs
+++ b/sdk/log/macro/src/lib.rs
@@ -1,5 +1,3 @@
-use std::sync::LazyLock;
-
 use proc_macro::TokenStream;
 use quote::quote;
 use regex::Regex;
@@ -9,9 +7,6 @@ use syn::{
     punctuated::Punctuated,
     Error, Expr, LitInt, LitStr, Token,
 };
-
-/// Regex pattern to match placeholders in the format string.
-static PLACEHOLDER: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\{.*?\}").unwrap());
 
 /// The default buffer size for the logger.
 const DEFAULT_BUFFER_SIZE: &str = "200";
@@ -90,7 +85,10 @@ pub fn log(input: TokenStream) -> TokenStream {
     } = parse_macro_input!(input as LogArgs);
     let parsed_string = format_string.value();
 
-    let placeholders: Vec<_> = PLACEHOLDER
+    // Regex pattern to match placeholders in the format string.
+    let placeholder_regex = Regex::new(r"\{.*?\}").unwrap();
+
+    let placeholders: Vec<_> = placeholder_regex
         .find_iter(&parsed_string)
         .map(|m| m.as_str())
         .collect();
@@ -127,7 +125,7 @@ pub fn log(input: TokenStream) -> TokenStream {
         // The parts of the format string with the placeholders replaced by arguments.
         let mut replaced_parts = Vec::new();
 
-        let parts: Vec<&str> = PLACEHOLDER.split(&parsed_string).collect();
+        let parts: Vec<&str> = placeholder_regex.split(&parsed_string).collect();
         let part_iter = parts.iter();
 
         let mut arg_iter = args.iter();


### PR DESCRIPTION
### Problem

While the `Logger` type supports precision formatting, there is not way to specify precision on the `log!` macro.

### Solution

Add precision support to `log!` macro. This follows a similar pattern as Rust `format!` string: to specify the precision of a value, the placeholder includes the number of decimal digits `{:.9}`.
```rust
let lamports = 1_000_000_000;
log!("Balance (SOL): {:.9}", lamports);
```