### PR TITLE
log: Add precision support to `str`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,14 +38,14 @@ version = "0.6.0"
 
 [[package]]
 name = "pinocchio-log"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "pinocchio-log-macro",
 ]
 
 [[package]]
 name = "pinocchio-log-macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "quote",
  "regex",

--- a/sdk/log/crate/Cargo.toml
+++ b/sdk/log/crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pinocchio-log"
 description = "Lightweight log utility for Solana programs"
-version = "0.1.0"
+version = "0.2.0"
 edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"

--- a/sdk/log/crate/src/lib.rs
+++ b/sdk/log/crate/src/lib.rs
@@ -126,7 +126,7 @@ mod tests {
     }
 
     #[test]
-    fn test_logger_with_args() {
+    fn test_logger_with_precision() {
         let mut logger = Logger::<10>::default();
 
         logger.append_with_args(200_000_000u64, &[Argument::Precision(2)]);
@@ -166,5 +166,19 @@ mod tests {
 
         logger.append_with_args(-2i64, &[Argument::Precision(9)]);
         assert!(&*logger == "-0.000000@".as_bytes());
+
+        logger.clear();
+
+        logger.append_with_args("0123456789", &[Argument::Precision(10)]);
+        assert!(&*logger == "0123456789".as_bytes());
+
+        logger.clear();
+
+        logger.append_with_args("0123456789", &[Argument::Precision(9)]);
+        assert!(&*logger == "...456789".as_bytes());
+
+        let mut logger = Logger::<3>::default();
+        logger.append_with_args("0123456789", &[Argument::Precision(9)]);
+        assert!(&*logger == "..@".as_bytes());
     }
 }

--- a/sdk/log/crate/src/lib.rs
+++ b/sdk/log/crate/src/lib.rs
@@ -169,16 +169,41 @@ mod tests {
 
         logger.clear();
 
-        logger.append_with_args("0123456789", &[Argument::Precision(10)]);
+        // This should have no effect.
+        logger.append_with_args("0123456789", &[Argument::Precision(2)]);
+        assert!(&*logger == "0123456789".as_bytes());
+    }
+
+    #[test]
+    fn test_logger_with_truncate() {
+        let mut logger = Logger::<10>::default();
+
+        logger.append_with_args("0123456789", &[Argument::TruncateEnd(10)]);
         assert!(&*logger == "0123456789".as_bytes());
 
         logger.clear();
 
-        logger.append_with_args("0123456789", &[Argument::Precision(9)]);
+        logger.append_with_args("0123456789", &[Argument::TruncateStart(10)]);
+        assert!(&*logger == "0123456789".as_bytes());
+
+        logger.clear();
+
+        logger.append_with_args("0123456789", &[Argument::TruncateEnd(9)]);
+        assert!(&*logger == "012345...".as_bytes());
+
+        logger.clear();
+
+        logger.append_with_args("0123456789", &[Argument::TruncateStart(9)]);
         assert!(&*logger == "...456789".as_bytes());
 
         let mut logger = Logger::<3>::default();
-        logger.append_with_args("0123456789", &[Argument::Precision(9)]);
+
+        logger.append_with_args("0123456789", &[Argument::TruncateEnd(9)]);
+        assert!(&*logger == "..@".as_bytes());
+
+        logger.clear();
+
+        logger.append_with_args("0123456789", &[Argument::TruncateStart(9)]);
         assert!(&*logger == "..@".as_bytes());
     }
 }

--- a/sdk/log/crate/src/logger.rs
+++ b/sdk/log/crate/src/logger.rs
@@ -57,7 +57,7 @@ impl<const BUFFER: usize> Logger<BUFFER> {
     }
 
     /// Append a value to the logger with formatting arguments.
-    #[inline]
+    #[inline(never)]
     pub fn append_with_args<T: Log>(&mut self, value: T, args: &[Argument]) {
         if self.is_full() {
             if BUFFER > 0 {
@@ -153,7 +153,7 @@ pub trait Log {
 macro_rules! impl_log_for_unsigned_integer {
     ( $type:tt, $max_digits:literal ) => {
         impl Log for $type {
-            #[inline]
+            #[inline(never)]
             fn write_with_args(&self, buffer: &mut [MaybeUninit<u8>], args: &[Argument]) -> usize {
                 if buffer.is_empty() {
                     return 0;
@@ -297,7 +297,7 @@ impl_log_for_unsigned_integer!(u128, 39);
 macro_rules! impl_log_for_signed {
     ( $type:tt, $unsigned_type:tt, $max_digits:literal ) => {
         impl Log for $type {
-            #[inline]
+            #[inline(never)]
             fn write_with_args(&self, buffer: &mut [MaybeUninit<u8>], args: &[Argument]) -> usize {
                 if buffer.is_empty() {
                     return 0;
@@ -340,7 +340,7 @@ impl_log_for_signed!(i128, u128, 39);
 
 /// Implement the log trait for the &str type.
 impl Log for &str {
-    #[inline]
+    #[inline(never)]
     fn debug_with_args(&self, buffer: &mut [MaybeUninit<u8>], _args: &[Argument]) -> usize {
         if buffer.is_empty() {
             return 0;
@@ -368,7 +368,7 @@ impl Log for &str {
         offset
     }
 
-    #[inline]
+    #[inline(never)]
     fn write_with_args(&self, buffer: &mut [MaybeUninit<u8>], _args: &[Argument]) -> usize {
         let length = core::cmp::min(buffer.len(), self.len());
         let offset = &mut buffer[..length];
@@ -408,7 +408,7 @@ macro_rules! impl_log_for_slice {
         }
     };
     ( @generate_write ) => {
-        #[inline]
+        #[inline(never)]
         fn write_with_args(&self, buffer: &mut [MaybeUninit<u8>], _args: &[Argument]) -> usize {
             if buffer.is_empty() {
                 return 0;

--- a/sdk/log/macro/Cargo.toml
+++ b/sdk/log/macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pinocchio-log-macro"
 description = "Macro for pinocchio log utility"
-version = "0.1.0"
+version = "0.2.0"
 edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"


### PR DESCRIPTION
### Problem

Precision formatting was added to `Logger` but it is currently ignored by the `str` implementation.

### Solution

Add support for precision when logging `str` values. This was done as separate `Argument` variants to encode the truncate position: `TruncateEnd` and `TruncateStart`. There are 3 cases for truncation:

1. The log buffer is large enough to hold the entire `str`: the whole `str` is logged.
2. The log buffer is smaller than the `str`, but large enough to hold a "`...`" slice and part of the `str`: the slice and part of the `str` are logged.
3. The log buffer is smaller than both the `str` and the "`...`" slice: the buffer is filled with `.` characters and the last character is set to `@`.