### PR TITLE
macro: Add truncate formatting

### DIFF
--- a/sdk/log/README.md
+++ b/sdk/log/README.md
@@ -108,9 +108,31 @@ logger.append_with_args(amount, &[Argument::Precision(9)]);
 logger.log()
 ```
 
-## Limitations
+And a maximum length for `&str` types with a truncate strategy:
+```rust
+use pinocchio_log::logger::{Attribute, Logger};
 
-Currently the `log!` macro only offers limited formatting options. Apart from the placeholder `"{}"` for argument values, it is possible to specify the number of decimals digits for numeric values.
+let program_name = "pinocchio-program";
+let mut logger = Logger::<100>::default();
+logger.append_with_args(program_name, &[Argument::TruncateStart(10)]);
+logger.log() // log message: "...program"
+
+let mut logger = Logger::<100>::default();
+logger.append_with_args(program_name, &[Argument::TruncateEnd(10)]);
+logger.log() // log message: "pinocchio-..."
+```
+
+## Formatting Options
+
+Formatting options are represented by `Attribute` variants and can be passed to the `Logger` when appending messages using `append_with_args`.
+
+| Variant                | Description                                     | Macro Format     |
+| ---------------------- | ----------------------------------------------- | ---------------- |
+| `Precision(u8)`        | Number of decimal places to display for numbers`*` | "{.*precision*}" |
+| `TruncateEnd(usize)`   | Truncate the output at the end when the specified maximum number of characters (size) is exceeded | "{<.*size*}"     |
+| `TruncateStart(usize)` | Truncate the output at the start when the specified maximum number of characters (size) is exceeded | "{>.*size*}"     |
+
+`*` The `Precision` adds a decimal formatting to integer numbers. This is useful to log numeric integer amounts that represent values with decimal precision.
 
 ## License
 

--- a/sdk/log/crate/src/logger.rs
+++ b/sdk/log/crate/src/logger.rs
@@ -56,13 +56,14 @@ impl<const BUFFER: usize> Deref for Logger<BUFFER> {
 impl<const BUFFER: usize> Logger<BUFFER> {
     /// Append a value to the logger.
     #[inline(always)]
-    pub fn append<T: Log>(&mut self, value: T) {
+    pub fn append<T: Log>(&mut self, value: T) -> &mut Self {
         self.append_with_args(value, &[]);
+        self
     }
 
     /// Append a value to the logger with formatting arguments.
     #[inline]
-    pub fn append_with_args<T: Log>(&mut self, value: T, args: &[Argument]) {
+    pub fn append_with_args<T: Log>(&mut self, value: T, args: &[Argument]) -> &mut Self {
         if self.is_full() {
             if BUFFER > 0 {
                 unsafe {
@@ -73,6 +74,8 @@ impl<const BUFFER: usize> Logger<BUFFER> {
         } else {
             self.offset += value.write_with_args(&mut self.buffer[self.offset..], args);
         }
+
+        self
     }
 
     /// Log the message in the buffer.


### PR DESCRIPTION
### Problem

There are two new `Attribute` variants (`TruncateEnd` and `TruncateStart`) that allows specifying a maximum length for `&str` log messages. These are not currently supported by the `log!` macro.

### Solution

Add support to both `TruncateEnd` and `TruncateStart` by introducing two new formatting strings:
- "{:>.*size*}" for `TruncateEnd`
- "{:<.*size*}" for `TruncateStart`

### Examples

```rust
use pinocchio_log::log;

let program_name = "pinocchio-program";

// log output: "...program"
log!(":<.10", program_name);

// log output: "pinocchio-..."
log!(":>.10", program_name);
```