### PR TITLE
Fix last  `u64` owner index on `close`

### DIFF
--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -436,7 +436,7 @@ impl AccountInfo {
         *(self.data_ptr().sub(48) as *mut u64) = 0u64;
         *(self.data_ptr().sub(40) as *mut u64) = 0u64;
         *(self.data_ptr().sub(32) as *mut u64) = 0u64;
-        *(self.data_ptr().sub(16) as *mut u64) = 0u64;
+        *(self.data_ptr().sub(24) as *mut u64) = 0u64;
         // Zero the account lamports.
         (*self.raw).lamports = 0;
         // Zero the account data length.


### PR DESCRIPTION
### Problem

`AccountInfo::close_unchecked` promises to clear the `lamports`, `data_len` and `owner` fields, but it misses the last `8` bytes of the owner `Pubkey` due to using an index that matches the `lamports` field.

### Solution

Update the index so the last `8` bytes of the owner are cleared.