### PR TITLE
Add close unstable

### DIFF
--- a/sdk/pinocchio/Cargo.toml
+++ b/sdk/pinocchio/Cargo.toml
@@ -17,4 +17,5 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [features]
+asm = []
 std = []

--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -444,7 +444,7 @@ impl AccountInfo {
     /// closing the account.
     ///
     /// This doesn't protect against future reinitialization of the account
-    /// since the account data will need to be zeroed out as well; otherwise the lenght,
+    /// since the account data will need to be zeroed out as well; otherwise the length,
     /// lamports and owner can be set again before the data is wiped out from
     /// the ledger using the keypair of the account being close.
     ///

--- a/sdk/pinocchio/src/lib.rs
+++ b/sdk/pinocchio/src/lib.rs
@@ -9,6 +9,10 @@
 //! [`solana-program`]: https://docs.rs/solana-program/latest/solana_program/
 
 #![no_std]
+#![cfg_attr(
+    all(feature = "asm", target_os = "solana"),
+    feature(asm_experimental_arch, asm_const)
+)]
 
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
### Problem

When PR #55 fixed the last index of the owner `Pubkey` on `close_unchecked`, it pushed the CUs used by the method to over `50`.

### Solution

Reimplement `close_unchecked` using the `sol_memset` syscall, which consumes `14` CUs instead. Since this is still over the original `7` CUs, this PR also re-adds the `close_unstable` which uses ASM – this variant takes `7` CUs.

The `close_unstable` can be enabled by using the feature `"asm"`.

Note: `close_unstable` courtesy of @L0STE and @deanmlittle 