### PR TITLE
Adds unchecked calls to system program

### DIFF
--- a/programs/system/src/instructions/allocate_with_seed.rs
+++ b/programs/system/src/instructions/allocate_with_seed.rs
@@ -1,6 +1,6 @@
 use pinocchio::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey};
 
-use crate::{InstructionData, InvokeParts};
+use crate::{InvokeParts, TruncatedInstructionData};
 
 /// Allocate space for and assign an account at an address derived
 /// from a base public key and a seed.
@@ -32,7 +32,9 @@ pub struct AllocateWithSeed<'a, 'b, 'c> {
 const N_ACCOUNTS: usize = 2;
 const DATA_LEN: usize = 112;
 
-impl<'a, 'b, 'c> From<AllocateWithSeed<'a, 'b, 'c>> for InvokeParts<'a, N_ACCOUNTS, DATA_LEN> {
+impl<'a, 'b, 'c> From<AllocateWithSeed<'a, 'b, 'c>>
+    for InvokeParts<'a, N_ACCOUNTS, TruncatedInstructionData<DATA_LEN>>
+{
     fn from(value: AllocateWithSeed<'a, 'b, 'c>) -> Self {
         Self {
             accounts: [value.account, value.base],
@@ -58,7 +60,7 @@ impl<'a, 'b, 'c> From<AllocateWithSeed<'a, 'b, 'c>> for InvokeParts<'a, N_ACCOUN
                 instruction_data[44..offset].copy_from_slice(value.seed.as_bytes());
                 instruction_data[offset..offset + 8].copy_from_slice(&value.space.to_le_bytes());
                 instruction_data[offset + 8..offset + 40].copy_from_slice(value.owner.as_ref());
-                InstructionData::truncated(instruction_data, offset + 40)
+                TruncatedInstructionData::new(instruction_data, offset + 40)
             },
         }
     }

--- a/programs/system/src/instructions/allocate_with_seed.rs
+++ b/programs/system/src/instructions/allocate_with_seed.rs
@@ -30,12 +30,9 @@ pub struct AllocateWithSeed<'a, 'b, 'c> {
 }
 
 const N_ACCOUNTS: usize = 2;
-const N_ACCOUNT_METAS: usize = 2;
 const DATA_LEN: usize = 112;
 
-impl<'a, 'b, 'c> From<AllocateWithSeed<'a, 'b, 'c>>
-    for InvokeParts<'a, N_ACCOUNTS, N_ACCOUNT_METAS, DATA_LEN>
-{
+impl<'a, 'b, 'c> From<AllocateWithSeed<'a, 'b, 'c>> for InvokeParts<'a, N_ACCOUNTS, DATA_LEN> {
     fn from(value: AllocateWithSeed<'a, 'b, 'c>) -> Self {
         Self {
             accounts: [value.account, value.base],
@@ -61,7 +58,7 @@ impl<'a, 'b, 'c> From<AllocateWithSeed<'a, 'b, 'c>>
                 instruction_data[44..offset].copy_from_slice(value.seed.as_bytes());
                 instruction_data[offset..offset + 8].copy_from_slice(&value.space.to_le_bytes());
                 instruction_data[offset + 8..offset + 40].copy_from_slice(value.owner.as_ref());
-                InstructionData::Truncated((instruction_data, offset + 40))
+                InstructionData::truncated(instruction_data, offset + 40)
             },
         }
     }

--- a/programs/system/src/instructions/allocate_with_seed.rs
+++ b/programs/system/src/instructions/allocate_with_seed.rs
@@ -1,10 +1,6 @@
-use pinocchio::{
-    account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
-    pubkey::Pubkey,
-    ProgramResult,
-};
+use pinocchio::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey};
+
+use crate::InvokeParts;
 
 /// Allocate space for and assign an account at an address derived
 /// from a base public key and a seed.
@@ -33,19 +29,27 @@ pub struct AllocateWithSeed<'a, 'b, 'c> {
     pub owner: &'c Pubkey,
 }
 
-impl AllocateWithSeed<'_, '_, '_> {
-    #[inline(always)]
-    pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
+const N_ACCOUNTS: usize = 2;
+const N_ACCOUNT_METAS: usize = 2;
+const DATA_LEN: usize = 112;
+
+impl<'a, 'b, 'c> InvokeParts for AllocateWithSeed<'a, 'b, 'c> {
+    type Accounts = [&'a AccountInfo; N_ACCOUNTS];
+    type AccountMetas = [AccountMeta<'a>; N_ACCOUNT_METAS];
+    type InstructionData = [u8; DATA_LEN];
+
+    fn accounts(&self) -> Self::Accounts {
+        [self.account, self.base]
     }
 
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // account metadata
-        let account_metas: [AccountMeta; 2] = [
+    fn account_metas(&self) -> Self::AccountMetas {
+        [
             AccountMeta::writable_signer(self.account.key()),
             AccountMeta::readonly_signer(self.base.key()),
-        ];
+        ]
+    }
 
+    fn instruction_data(&self) -> (Self::InstructionData, usize) {
         // instruction data
         // - [0..4  ]: instruction discriminator
         // - [4..36 ]: base pubkey
@@ -53,7 +57,7 @@ impl AllocateWithSeed<'_, '_, '_> {
         // - [44..  ]: seed (max 32)
         // - [..  +8]: account space
         // - [.. +32]: owner pubkey
-        let mut instruction_data = [0; 112];
+        let mut instruction_data = [0; DATA_LEN];
         instruction_data[0] = 9;
         instruction_data[4..36].copy_from_slice(self.base.key());
         instruction_data[36..44].copy_from_slice(&u64::to_le_bytes(self.seed.len() as u64));
@@ -62,13 +66,6 @@ impl AllocateWithSeed<'_, '_, '_> {
         instruction_data[44..offset].copy_from_slice(self.seed.as_bytes());
         instruction_data[offset..offset + 8].copy_from_slice(&self.space.to_le_bytes());
         instruction_data[offset + 8..offset + 40].copy_from_slice(self.owner.as_ref());
-
-        let instruction = Instruction {
-            program_id: &crate::ID,
-            accounts: &account_metas,
-            data: &instruction_data[..offset + 40],
-        };
-
-        invoke_signed(&instruction, &[self.account, self.base], signers)
+        (instruction_data, offset + 40)
     }
 }

--- a/programs/system/src/instructions/allocate_with_seed.rs
+++ b/programs/system/src/instructions/allocate_with_seed.rs
@@ -1,6 +1,6 @@
 use pinocchio::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey};
 
-use crate::InvokeParts;
+use crate::{InstructionData, InvokeParts};
 
 /// Allocate space for and assign an account at an address derived
 /// from a base public key and a seed.
@@ -33,39 +33,36 @@ const N_ACCOUNTS: usize = 2;
 const N_ACCOUNT_METAS: usize = 2;
 const DATA_LEN: usize = 112;
 
-impl<'a, 'b, 'c> InvokeParts for AllocateWithSeed<'a, 'b, 'c> {
-    type Accounts = [&'a AccountInfo; N_ACCOUNTS];
-    type AccountMetas = [AccountMeta<'a>; N_ACCOUNT_METAS];
-    type InstructionData = [u8; DATA_LEN];
+impl<'a, 'b, 'c> From<AllocateWithSeed<'a, 'b, 'c>>
+    for InvokeParts<'a, N_ACCOUNTS, N_ACCOUNT_METAS, DATA_LEN>
+{
+    fn from(value: AllocateWithSeed<'a, 'b, 'c>) -> Self {
+        Self {
+            accounts: [value.account, value.base],
+            account_metas: [
+                AccountMeta::writable_signer(value.account.key()),
+                AccountMeta::readonly_signer(value.base.key()),
+            ],
+            instruction_data: {
+                // instruction data
+                // - [0..4  ]: instruction discriminator
+                // - [4..36 ]: base pubkey
+                // - [36..44]: seed length
+                // - [44..  ]: seed (max 32)
+                // - [..  +8]: account space
+                // - [.. +32]: owner pubkey
+                let mut instruction_data = [0; DATA_LEN];
+                instruction_data[0] = 9;
+                instruction_data[4..36].copy_from_slice(value.base.key());
+                instruction_data[36..44]
+                    .copy_from_slice(&u64::to_le_bytes(value.seed.len() as u64));
 
-    fn accounts(&self) -> Self::Accounts {
-        [self.account, self.base]
-    }
-
-    fn account_metas(&self) -> Self::AccountMetas {
-        [
-            AccountMeta::writable_signer(self.account.key()),
-            AccountMeta::readonly_signer(self.base.key()),
-        ]
-    }
-
-    fn instruction_data(&self) -> (Self::InstructionData, usize) {
-        // instruction data
-        // - [0..4  ]: instruction discriminator
-        // - [4..36 ]: base pubkey
-        // - [36..44]: seed length
-        // - [44..  ]: seed (max 32)
-        // - [..  +8]: account space
-        // - [.. +32]: owner pubkey
-        let mut instruction_data = [0; DATA_LEN];
-        instruction_data[0] = 9;
-        instruction_data[4..36].copy_from_slice(self.base.key());
-        instruction_data[36..44].copy_from_slice(&u64::to_le_bytes(self.seed.len() as u64));
-
-        let offset = 44 + self.seed.len();
-        instruction_data[44..offset].copy_from_slice(self.seed.as_bytes());
-        instruction_data[offset..offset + 8].copy_from_slice(&self.space.to_le_bytes());
-        instruction_data[offset + 8..offset + 40].copy_from_slice(self.owner.as_ref());
-        (instruction_data, offset + 40)
+                let offset = 44 + value.seed.len();
+                instruction_data[44..offset].copy_from_slice(value.seed.as_bytes());
+                instruction_data[offset..offset + 8].copy_from_slice(&value.space.to_le_bytes());
+                instruction_data[offset + 8..offset + 40].copy_from_slice(value.owner.as_ref());
+                InstructionData::Truncated((instruction_data, offset + 40))
+            },
+        }
     }
 }

--- a/programs/system/src/instructions/allocate_with_seed.rs
+++ b/programs/system/src/instructions/allocate_with_seed.rs
@@ -37,6 +37,7 @@ impl<'a, 'b, 'c> From<AllocateWithSeed<'a, 'b, 'c>>
 {
     fn from(value: AllocateWithSeed<'a, 'b, 'c>) -> Self {
         Self {
+            program_id: crate::ID,
             accounts: [value.account, value.base],
             account_metas: [
                 AccountMeta::writable_signer(value.account.key()),

--- a/programs/system/src/instructions/authorize_nonce_account.rs
+++ b/programs/system/src/instructions/authorize_nonce_account.rs
@@ -1,10 +1,6 @@
-use pinocchio::{
-    account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
-    pubkey::Pubkey,
-    ProgramResult,
-};
+use pinocchio::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey};
+
+use crate::{FullInstructionData, InvokeParts};
 
 /// Change the entity authorized to execute nonce instructions on the account.
 ///
@@ -24,32 +20,30 @@ pub struct AuthorizeNonceAccount<'a, 'b> {
     pub new_authority: &'b Pubkey,
 }
 
-impl AuthorizeNonceAccount<'_, '_> {
-    #[inline(always)]
-    pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
+const N_ACCOUNTS: usize = 2;
+const DATA_LEN: usize = 36;
 
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // account metadata
-        let account_metas: [AccountMeta; 2] = [
-            AccountMeta::writable(self.account.key()),
-            AccountMeta::readonly_signer(self.authority.key()),
-        ];
+impl<'a, 'b> From<AuthorizeNonceAccount<'a, 'b>>
+    for InvokeParts<'a, N_ACCOUNTS, FullInstructionData<DATA_LEN>>
+{
+    fn from(value: AuthorizeNonceAccount<'a, 'b>) -> Self {
+        InvokeParts {
+            program_id: crate::ID,
+            accounts: [value.account, value.authority],
+            account_metas: [
+                AccountMeta::writable(value.account.key()),
+                AccountMeta::readonly_signer(value.authority.key()),
+            ],
+            instruction_data: {
+                // instruction data
+                // -  [0..4 ]: instruction discriminator
+                // -  [4..12]: lamports
+                let mut instruction_data = [0; DATA_LEN];
+                instruction_data[0] = 7;
+                instruction_data[4..36].copy_from_slice(value.new_authority);
 
-        // instruction data
-        // -  [0..4 ]: instruction discriminator
-        // -  [4..12]: lamports
-        let mut instruction_data = [0; 36];
-        instruction_data[0] = 7;
-        instruction_data[4..36].copy_from_slice(self.new_authority);
-
-        let instruction = Instruction {
-            program_id: &crate::ID,
-            accounts: &account_metas,
-            data: &instruction_data,
-        };
-
-        invoke_signed(&instruction, &[self.account, self.authority], signers)
+                FullInstructionData::new(instruction_data)
+            },
+        }
     }
 }

--- a/programs/system/src/instructions/create_account.rs
+++ b/programs/system/src/instructions/create_account.rs
@@ -1,10 +1,6 @@
-use pinocchio::{
-    account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
-    pubkey::Pubkey,
-    ProgramResult,
-};
+use pinocchio::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey};
+
+use crate::{FullInstructionData, InvokeParts};
 
 /// Create a new account.
 ///
@@ -28,36 +24,32 @@ pub struct CreateAccount<'a> {
     pub owner: &'a Pubkey,
 }
 
-impl CreateAccount<'_> {
-    #[inline(always)]
-    pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
+const N_ACCOUNTS: usize = 2;
+const DATA_LEN: usize = 52;
 
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // account metadata
-        let account_metas: [AccountMeta; 2] = [
-            AccountMeta::writable_signer(self.from.key()),
-            AccountMeta::writable_signer(self.to.key()),
-        ];
+impl<'a> From<CreateAccount<'a>> for InvokeParts<'a, N_ACCOUNTS, FullInstructionData<DATA_LEN>> {
+    fn from(value: CreateAccount<'a>) -> Self {
+        InvokeParts {
+            program_id: crate::ID,
+            accounts: [value.from, value.to],
+            account_metas: [
+                AccountMeta::writable_signer(value.from.key()),
+                AccountMeta::writable_signer(value.to.key()),
+            ],
+            instruction_data: {
+                // instruction data
+                // - [0..4  ]: instruction discriminator
+                // - [4..12 ]: lamports
+                // - [12..20]: account space
+                // - [20..52]: owner pubkey
+                let mut instruction_data = [0; DATA_LEN];
+                // create account instruction has a '0' discriminator
+                instruction_data[4..12].copy_from_slice(&value.lamports.to_le_bytes());
+                instruction_data[12..20].copy_from_slice(&value.space.to_le_bytes());
+                instruction_data[20..52].copy_from_slice(value.owner.as_ref());
 
-        // instruction data
-        // - [0..4  ]: instruction discriminator
-        // - [4..12 ]: lamports
-        // - [12..20]: account space
-        // - [20..52]: owner pubkey
-        let mut instruction_data = [0; 52];
-        // create account instruction has a '0' discriminator
-        instruction_data[4..12].copy_from_slice(&self.lamports.to_le_bytes());
-        instruction_data[12..20].copy_from_slice(&self.space.to_le_bytes());
-        instruction_data[20..52].copy_from_slice(self.owner.as_ref());
-
-        let instruction = Instruction {
-            program_id: &crate::ID,
-            accounts: &account_metas,
-            data: &instruction_data,
-        };
-
-        invoke_signed(&instruction, &[self.from, self.to], signers)
+                FullInstructionData::new(instruction_data)
+            },
+        }
     }
 }

--- a/programs/system/src/instructions/transfer.rs
+++ b/programs/system/src/instructions/transfer.rs
@@ -1,6 +1,6 @@
 use pinocchio::{account_info::AccountInfo, instruction::AccountMeta};
 
-use crate::{InstructionData, InvokeParts};
+use crate::{FullInstructionData, InvokeParts};
 
 /// Transfer lamports.
 ///
@@ -21,7 +21,7 @@ pub struct Transfer<'a> {
 const N_ACCOUNTS: usize = 2;
 const DATA_LEN: usize = 12;
 
-impl<'a> From<Transfer<'a>> for InvokeParts<'a, N_ACCOUNTS, DATA_LEN> {
+impl<'a> From<Transfer<'a>> for InvokeParts<'a, N_ACCOUNTS, FullInstructionData<DATA_LEN>> {
     fn from(value: Transfer<'a>) -> Self {
         InvokeParts {
             accounts: [value.from, value.to],
@@ -36,7 +36,7 @@ impl<'a> From<Transfer<'a>> for InvokeParts<'a, N_ACCOUNTS, DATA_LEN> {
                 let mut instruction_data = [0; DATA_LEN];
                 instruction_data[0] = 2;
                 instruction_data[4..12].copy_from_slice(&value.lamports.to_le_bytes());
-                InstructionData::Full(instruction_data)
+                FullInstructionData::new(instruction_data)
             },
         }
     }

--- a/programs/system/src/instructions/transfer.rs
+++ b/programs/system/src/instructions/transfer.rs
@@ -1,6 +1,6 @@
 use pinocchio::{account_info::AccountInfo, instruction::AccountMeta};
 
-use crate::InvokeParts;
+use crate::{InstructionData, InvokeParts};
 
 /// Transfer lamports.
 ///
@@ -22,29 +22,23 @@ const N_ACCOUNTS: usize = 2;
 const N_ACCOUNT_METAS: usize = 2;
 const DATA_LEN: usize = 12;
 
-impl<'a> InvokeParts for Transfer<'a> {
-    type Accounts = [&'a AccountInfo; N_ACCOUNTS];
-    type AccountMetas = [AccountMeta<'a>; N_ACCOUNT_METAS];
-    type InstructionData = [u8; DATA_LEN];
-
-    fn accounts(&self) -> Self::Accounts {
-        [self.to, self.from]
-    }
-
-    fn account_metas(&self) -> Self::AccountMetas {
-        [
-            AccountMeta::writable_signer(self.from.key()),
-            AccountMeta::writable(self.to.key()),
-        ]
-    }
-
-    fn instruction_data(&self) -> (Self::InstructionData, usize) {
-        // instruction data
-        // -  [0..4 ]: instruction discriminator
-        // -  [4..12]: lamports amount
-        let mut instruction_data = [0; DATA_LEN];
-        instruction_data[0] = 2;
-        instruction_data[4..12].copy_from_slice(&self.lamports.to_le_bytes());
-        (instruction_data, DATA_LEN)
+impl<'a> From<Transfer<'a>> for InvokeParts<'a, N_ACCOUNTS, N_ACCOUNT_METAS, DATA_LEN> {
+    fn from(value: Transfer<'a>) -> Self {
+        InvokeParts {
+            accounts: [value.to, value.from],
+            account_metas: [
+                AccountMeta::writable_signer(value.from.key()),
+                AccountMeta::writable(value.to.key()),
+            ],
+            instruction_data: {
+                // instruction data
+                // -  [0..4 ]: instruction discriminator
+                // -  [4..12]: lamports amount
+                let mut instruction_data = [0; DATA_LEN];
+                instruction_data[0] = 2;
+                instruction_data[4..12].copy_from_slice(&value.lamports.to_le_bytes());
+                InstructionData::Full(instruction_data)
+            },
+        }
     }
 }

--- a/programs/system/src/instructions/transfer.rs
+++ b/programs/system/src/instructions/transfer.rs
@@ -19,13 +19,12 @@ pub struct Transfer<'a> {
 }
 
 const N_ACCOUNTS: usize = 2;
-const N_ACCOUNT_METAS: usize = 2;
 const DATA_LEN: usize = 12;
 
-impl<'a> From<Transfer<'a>> for InvokeParts<'a, N_ACCOUNTS, N_ACCOUNT_METAS, DATA_LEN> {
+impl<'a> From<Transfer<'a>> for InvokeParts<'a, N_ACCOUNTS, DATA_LEN> {
     fn from(value: Transfer<'a>) -> Self {
         InvokeParts {
-            accounts: [value.to, value.from],
+            accounts: [value.from, value.to],
             account_metas: [
                 AccountMeta::writable_signer(value.from.key()),
                 AccountMeta::writable(value.to.key()),

--- a/programs/system/src/instructions/transfer.rs
+++ b/programs/system/src/instructions/transfer.rs
@@ -1,6 +1,6 @@
 use pinocchio::{account_info::AccountInfo, instruction::AccountMeta};
 
-use crate::InstructionParts;
+use crate::InvokeParts;
 
 /// Transfer lamports.
 ///
@@ -22,7 +22,7 @@ const N_ACCOUNTS: usize = 2;
 const N_ACCOUNT_METAS: usize = 2;
 const DATA_LEN: usize = 12;
 
-impl<'a> InstructionParts for Transfer<'a> {
+impl<'a> InvokeParts for Transfer<'a> {
     type Accounts = [&'a AccountInfo; N_ACCOUNTS];
     type AccountMetas = [AccountMeta<'a>; N_ACCOUNT_METAS];
     type InstructionData = [u8; DATA_LEN];
@@ -38,13 +38,13 @@ impl<'a> InstructionParts for Transfer<'a> {
         ]
     }
 
-    fn instruction_data(&self) -> Self::InstructionData {
+    fn instruction_data(&self) -> (Self::InstructionData, usize) {
         // instruction data
         // -  [0..4 ]: instruction discriminator
         // -  [4..12]: lamports amount
-        let mut instruction_data = [0; 12];
+        let mut instruction_data = [0; DATA_LEN];
         instruction_data[0] = 2;
         instruction_data[4..12].copy_from_slice(&self.lamports.to_le_bytes());
-        instruction_data
+        (instruction_data, DATA_LEN)
     }
 }

--- a/programs/system/src/instructions/transfer.rs
+++ b/programs/system/src/instructions/transfer.rs
@@ -24,6 +24,7 @@ const DATA_LEN: usize = 12;
 impl<'a> From<Transfer<'a>> for InvokeParts<'a, N_ACCOUNTS, FullInstructionData<DATA_LEN>> {
     fn from(value: Transfer<'a>) -> Self {
         InvokeParts {
+            program_id: crate::ID,
             accounts: [value.from, value.to],
             account_metas: [
                 AccountMeta::writable_signer(value.from.key()),

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -29,6 +29,7 @@ pub trait Invoke: Sized {
     }
 
     fn invoke_signed(self, signers: &[Signer]) -> pinocchio::ProgramResult;
+    unsafe fn invoke_singed_access_unchecked(self, signers: &[Signer]) -> pinocchio::ProgramResult;
 }
 
 impl<'a, const N: usize, const M: usize, const J: usize, T> Invoke for T
@@ -47,5 +48,15 @@ where
             data: Self::instruction_data_modifer(&data),
         };
         cpi::invoke_signed(&instruction, &self.accounts(), signers)
+    }
+
+    unsafe fn invoke_singed_access_unchecked(self, signers: &[Signer]) -> pinocchio::ProgramResult {
+        let data = self.instruction_data();
+        let instruction = Instruction {
+            program_id: &crate::ID,
+            accounts: &self.account_metas(),
+            data: Self::instruction_data_modifer(&data),
+        };
+        cpi::invoke_signed_access_unchecked(&instruction, &self.accounts(), signers)
     }
 }

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -11,23 +11,37 @@ pub mod instructions;
 
 pinocchio_pubkey::declare_id!("11111111111111111111111111111111");
 
-pub trait InvokeParts {
-    type Accounts;
-    type AccountMetas;
-    type InstructionData;
-
-    fn accounts(&self) -> Self::Accounts;
-    fn account_metas(&self) -> Self::AccountMetas;
-    fn instruction_data(&self) -> (Self::InstructionData, usize);
+pub struct InvokeParts<'a, const N: usize, const M: usize, const J: usize> {
+    pub accounts: [&'a AccountInfo; N],
+    pub account_metas: [AccountMeta<'a>; M],
+    pub instruction_data: InstructionData<J>,
 }
 
-pub trait Invoke<const N: usize>: Sized {
+pub enum InstructionData<const N: usize> {
+    Full([u8; N]),
+    Truncated(([u8; N], usize)),
+}
+
+impl<const N: usize> InstructionData<N> {
+    pub fn data(&self) -> &[u8] {
+        match *self {
+            InstructionData::Full(ref data) => data,
+            InstructionData::Truncated((ref data, end)) => &data[..end],
+        }
+    }
+}
+
+pub trait Invoke<'a, const N: usize, const M: usize, const J: usize>:
+    Into<InvokeParts<'a, N, M, J>>
+{
     fn invoke(self) -> pinocchio::ProgramResult {
         self.invoke_signed(&[])
     }
 
     fn invoke_signed(self, signers: &[Signer]) -> pinocchio::ProgramResult {
-        self.invoke_invoker(signers, |ix, acc, sigs| cpi::invoke_signed(&ix, acc, sigs))
+        invoke_invoker(self.into(), signers, |ix, acc, sigs| {
+            cpi::invoke_signed(&ix, acc, sigs)
+        })
     }
 
     unsafe fn invoke_access_unchecked(self) -> pinocchio::ProgramResult {
@@ -35,37 +49,26 @@ pub trait Invoke<const N: usize>: Sized {
     }
 
     unsafe fn invoke_singed_access_unchecked(self, signers: &[Signer]) -> pinocchio::ProgramResult {
-        self.invoke_invoker(signers, |ix, acc, sigs| unsafe {
+        invoke_invoker(self.into(), signers, |ix, acc, sigs| unsafe {
             cpi::invoke_signed_access_unchecked(&ix, acc, sigs)
         })
     }
-
-    fn invoke_invoker(
-        self,
-        signers: &[Signer],
-        invoker: impl FnOnce(Instruction, &[&AccountInfo; N], &[Signer]) -> pinocchio::ProgramResult,
-    ) -> pinocchio::ProgramResult;
 }
 
-impl<'a, const N: usize, const M: usize, const J: usize, T> Invoke<N> for T
-where
-    T: InvokeParts<
-        Accounts = [&'a AccountInfo; N],
-        AccountMetas = [AccountMeta<'a>; M],
-        InstructionData = [u8; J],
-    >,
+impl<'a, const N: usize, const M: usize, const J: usize, T> Invoke<'a, N, M, J> for T where
+    T: Into<InvokeParts<'a, N, M, J>>
 {
-    fn invoke_invoker(
-        self,
-        signers: &[Signer],
-        invoker: impl FnOnce(Instruction, &[&AccountInfo; N], &[Signer]) -> pinocchio::ProgramResult,
-    ) -> pinocchio::ProgramResult {
-        let (data, end) = self.instruction_data();
-        let instruction = Instruction {
-            program_id: &crate::ID,
-            accounts: &self.account_metas(),
-            data: &data[..end],
-        };
-        invoker(instruction, &self.accounts(), signers)
-    }
+}
+
+fn invoke_invoker<'a, const N: usize, const M: usize, const J: usize>(
+    invoke_parts: InvokeParts<'a, N, M, J>,
+    signers: &[Signer],
+    invoker: impl FnOnce(Instruction, &[&AccountInfo; N], &[Signer]) -> pinocchio::ProgramResult,
+) -> pinocchio::ProgramResult {
+    let instruction = Instruction {
+        program_id: &crate::ID,
+        accounts: &invoke_parts.account_metas,
+        data: invoke_parts.instruction_data.data(),
+    };
+    invoker(instruction, &invoke_parts.accounts, signers)
 }

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -1,5 +1,51 @@
 #![no_std]
+use pinocchio::{
+    account_info::AccountInfo,
+    cpi,
+    instruction::{AccountMeta, Instruction, Signer},
+};
 
 pub mod instructions;
 
 pinocchio_pubkey::declare_id!("11111111111111111111111111111111");
+
+pub trait InstructionParts {
+    type Accounts;
+    type AccountMetas;
+    type InstructionData;
+
+    fn accounts(&self) -> Self::Accounts;
+    fn account_metas(&self) -> Self::AccountMetas;
+    fn instruction_data(&self) -> Self::InstructionData;
+
+    fn instruction_data_modifer(data: &[u8]) -> &[u8] {
+        data
+    }
+}
+
+pub trait Invoke: Sized {
+    fn invoke(self) -> pinocchio::ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    fn invoke_signed(self, signers: &[Signer]) -> pinocchio::ProgramResult;
+}
+
+impl<'a, const N: usize, const M: usize, const J: usize, T> Invoke for T
+where
+    T: InstructionParts<
+        Accounts = [&'a AccountInfo; N],
+        AccountMetas = [AccountMeta<'a>; M],
+        InstructionData = [u8; J],
+    >,
+{
+    fn invoke_signed(self, signers: &[Signer]) -> pinocchio::ProgramResult {
+        let data = self.instruction_data();
+        let instruction = Instruction {
+            program_id: &crate::ID,
+            accounts: &self.account_metas(),
+            data: Self::instruction_data_modifer(&data),
+        };
+        cpi::invoke_signed(&instruction, &self.accounts(), signers)
+    }
+}

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -34,13 +34,19 @@ pub struct TruncatedInstructionData<const N: usize> {
     size: usize,
 }
 
+impl<const N: usize> TruncatedInstructionData<N> {
+    pub fn new(data: [u8; N], size: usize) -> Self {
+        Self { data, size }
+    }
+}
+
 pub struct SliceInstructionData<'a> {
     data: &'a [u8],
 }
 
-impl<const N: usize> TruncatedInstructionData<N> {
-    pub fn new(data: [u8; N], size: usize) -> Self {
-        Self { data, size }
+impl<'a> SliceInstructionData<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        Self { data }
     }
 }
 

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -40,16 +40,6 @@ impl<const N: usize> TruncatedInstructionData<N> {
     }
 }
 
-pub struct SliceInstructionData<'a> {
-    data: &'a [u8],
-}
-
-impl<'a> SliceInstructionData<'a> {
-    pub fn new(data: &'a [u8]) -> Self {
-        Self { data }
-    }
-}
-
 pub trait InstructionData {
     fn as_slice(&self) -> &[u8];
     fn len(&self) -> usize;
@@ -72,16 +62,6 @@ impl<const N: usize> InstructionData for TruncatedInstructionData<N> {
 
     fn len(&self) -> usize {
         self.size
-    }
-}
-
-impl<'a> InstructionData for SliceInstructionData<'a> {
-    fn as_slice(&self) -> &[u8] {
-        self.data
-    }
-
-    fn len(&self) -> usize {
-        self.data.len()
     }
 }
 

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -1,4 +1,6 @@
 #![no_std]
+use core::usize;
+
 use pinocchio::{
     account_info::AccountInfo,
     cpi,
@@ -9,54 +11,61 @@ pub mod instructions;
 
 pinocchio_pubkey::declare_id!("11111111111111111111111111111111");
 
-pub trait InstructionParts {
+pub trait InvokeParts {
     type Accounts;
     type AccountMetas;
     type InstructionData;
 
     fn accounts(&self) -> Self::Accounts;
     fn account_metas(&self) -> Self::AccountMetas;
-    fn instruction_data(&self) -> Self::InstructionData;
-
-    fn instruction_data_modifer(data: &[u8]) -> &[u8] {
-        data
-    }
+    fn instruction_data(&self) -> (Self::InstructionData, usize);
 }
 
-pub trait Invoke: Sized {
+pub trait Invoke<const N: usize>: Sized {
     fn invoke(self) -> pinocchio::ProgramResult {
         self.invoke_signed(&[])
     }
 
-    fn invoke_signed(self, signers: &[Signer]) -> pinocchio::ProgramResult;
-    unsafe fn invoke_singed_access_unchecked(self, signers: &[Signer]) -> pinocchio::ProgramResult;
+    fn invoke_signed(self, signers: &[Signer]) -> pinocchio::ProgramResult {
+        self.invoke_invoker(signers, |ix, acc, sigs| cpi::invoke_signed(&ix, acc, sigs))
+    }
+
+    unsafe fn invoke_access_unchecked(self) -> pinocchio::ProgramResult {
+        self.invoke_singed_access_unchecked(&[])
+    }
+
+    unsafe fn invoke_singed_access_unchecked(self, signers: &[Signer]) -> pinocchio::ProgramResult {
+        self.invoke_invoker(signers, |ix, acc, sigs| unsafe {
+            cpi::invoke_signed_access_unchecked(&ix, acc, sigs)
+        })
+    }
+
+    fn invoke_invoker(
+        self,
+        signers: &[Signer],
+        invoker: impl FnOnce(Instruction, &[&AccountInfo; N], &[Signer]) -> pinocchio::ProgramResult,
+    ) -> pinocchio::ProgramResult;
 }
 
-impl<'a, const N: usize, const M: usize, const J: usize, T> Invoke for T
+impl<'a, const N: usize, const M: usize, const J: usize, T> Invoke<N> for T
 where
-    T: InstructionParts<
+    T: InvokeParts<
         Accounts = [&'a AccountInfo; N],
         AccountMetas = [AccountMeta<'a>; M],
         InstructionData = [u8; J],
     >,
 {
-    fn invoke_signed(self, signers: &[Signer]) -> pinocchio::ProgramResult {
-        let data = self.instruction_data();
+    fn invoke_invoker(
+        self,
+        signers: &[Signer],
+        invoker: impl FnOnce(Instruction, &[&AccountInfo; N], &[Signer]) -> pinocchio::ProgramResult,
+    ) -> pinocchio::ProgramResult {
+        let (data, end) = self.instruction_data();
         let instruction = Instruction {
             program_id: &crate::ID,
             accounts: &self.account_metas(),
-            data: Self::instruction_data_modifer(&data),
+            data: &data[..end],
         };
-        cpi::invoke_signed(&instruction, &self.accounts(), signers)
-    }
-
-    unsafe fn invoke_singed_access_unchecked(self, signers: &[Signer]) -> pinocchio::ProgramResult {
-        let data = self.instruction_data();
-        let instruction = Instruction {
-            program_id: &crate::ID,
-            accounts: &self.account_metas(),
-            data: Self::instruction_data_modifer(&data),
-        };
-        cpi::invoke_signed_access_unchecked(&instruction, &self.accounts(), signers)
+        invoker(instruction, &self.accounts(), signers)
     }
 }

--- a/sdk/pinocchio/src/cpi.rs
+++ b/sdk/pinocchio/src/cpi.rs
@@ -214,9 +214,7 @@ pub unsafe fn invoke_signed_access_unchecked<const ACCOUNTS: usize>(
         let account_info = account_infos[index];
         let account_meta = &instruction.accounts[index];
 
-        if account_info.key() != account_meta.pubkey
-            || !account_info.is_writable() & account_meta.is_writable
-        {
+        if account_info.key() != account_meta.pubkey {
             return Err(ProgramError::InvalidArgument);
         }
 
@@ -268,9 +266,7 @@ pub unsafe fn slice_invoke_signed_access_unchecked(
     let mut len = 0;
 
     for (account_info, account_meta) in account_infos.iter().zip(instruction.accounts.iter()) {
-        if account_info.key() != account_meta.pubkey
-            || !account_info.is_writable() & account_meta.is_writable
-        {
+        if account_info.key() != account_meta.pubkey {
             return Err(ProgramError::InvalidArgument);
         }
 


### PR DESCRIPTION
## Problem
The predefined solana programs(`system`, `token`, etc.) only expose `invoke` and `invoke_signed` calls. It would be nice to have `unsafe` calls as well. 

## Solution

- Adds `Invoke` trait that contains default implementations for 'invoke' and 'invoke_signed' as well as for the unsafe counter parts. 
- `Invoke` is auto implemented for any type that can convert into `InvokeParts` which contains all the necessary information to run an invoke call. 
- Implements `From<T> for InvokeParts` for all instructions 

 ## NOTES
 - This PR is only focused on updating the system program.
 - #124  