### PR TITLE
Improve allocators set up

### DIFF
--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -33,7 +33,7 @@ pub const SUCCESS: u64 = super::SUCCESS;
 /// Declare the program entrypoint and set up global handlers.
 ///
 /// This macro is deprecated and will be removed in a future version. It is recommended to
-/// use the [`entrypoint_with_allocator_and_panic_handler`] macro instead.
+/// use the [`crate::entrypoint_with_allocator_and_panic_handler`] macro instead.
 #[deprecated(
     since = "0.8.4",
     note = "Use the `entrypoint_with_allocator_and_panic_handler` macro instead"
@@ -119,9 +119,10 @@ macro_rules! entrypoint {
 /// should be used when the program or any of its dependencies are dependent on the `std` library.
 ///
 /// When the program and all its dependencies are `no_std`, it is necessary to set a
-/// `#[panic_handler]` to handle panics. This is done by the [`nostd_panic_handler`] macro. In this
-/// case, it is not possible to use the `entrypoint_with_allocator_and_panic_handler` macro. Use the
-/// [`program_entrypoint`] macro instead and set up the allocator and panic handler manually.
+/// `#[panic_handler]` to handle panics. This is done by the [`crate::nostd_panic_handler`](https://docs.rs/pinocchio/latest/pinocchio/macro.nostd_panic_handler.html)
+/// macro. In this case, it is not possible to use the `entrypoint_with_allocator_and_panic_handler`
+/// macro. Use the [`crate::program_entrypoint`] macro instead and set up the allocator and panic
+/// handler manually.
 #[macro_export]
 macro_rules! entrypoint_with_allocator_and_panic_handler {
     ( $process_instruction:ident ) => {
@@ -138,7 +139,7 @@ macro_rules! entrypoint_with_allocator_and_panic_handler {
 
 /// Declare the program entrypoint.
 ///
-/// This macro is similar to the [`entrypoint_with_allocator_and_panic_handler`] macro, but it does
+/// This macro is similar to the [`crate::entrypoint_with_allocator_and_panic_handler`] macro, but it does
 /// not set up a global allocator nor a panic handler. This is useful when the program will set up
 /// its own allocator and panic handler.
 #[macro_export]

--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -314,7 +314,7 @@ macro_rules! nostd_panic_handler {
         ///
         /// This links the `std` library, which will set up a default panic handler.
         #[cfg(not(target_os = "solana"))]
-        mod __private {
+        mod __private_panic_handler {
             extern crate std as __std;
         }
     };
@@ -338,7 +338,7 @@ macro_rules! default_allocator {
         ///
         /// This links the `std` library, which will set up a default global allocator.
         #[cfg(not(target_os = "solana"))]
-        mod __private {
+        mod __private_alloc {
             extern crate std as __std;
         }
     };
@@ -433,7 +433,7 @@ macro_rules! static_allocator {
         ///
         /// This links the `std` library, which will set up a default global allocator.
         #[cfg(not(target_os = "solana"))]
-        mod __private {
+        mod __private_alloc {
             extern crate std as __std;
         }
     };


### PR DESCRIPTION
### Problem

Currently, the "fallback" panic handler and allocator set up creates different problems when using `cargo test` or `cargo test-sbf`. This happens since tests in general depend on the `std` and therefore create a conflict when the fallback tries to set up a panic handler or global allocator.

### Solution

This PR improves the set up of the fallbacks by simply linking the `std` library instead of trying to set them up, avoiding conflicts if another library links the `std`. Note that the `std` is only linked in targets different than `"solana"`, so `no_std` programs are not affected.

It also addresses a couple of comments from #136:
* deprecate `entrypoint` macro in favour of `entrypoint_with_allocator_and_panic_handler`
* deprecate `no_allocator` macro in favour of `static_allocator`
* remove the need for `feature(const_mut_refs)`

cc: @publicqi 