### PR TITLE
Add `const_allocator` macro

### DIFF
--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -569,7 +569,7 @@ macro_rules! const_allocator {
                         // does not exceed the heap size.
                         __len: if len > ($crate::entrypoint::HEAP_LENGTH as usize) {
                             panic!("Heap allocation overflow: \
-                                The size of the struct exceeds the available heap space.");
+                                The size of the allocated memory exceeds the available heap space.");
                             } else {
                                 $crate::entrypoint::HEAP_LENGTH - len
                             },

--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -581,7 +581,7 @@ macro_rules! const_allocator {
             }
 
             // A static instance of the allocator.
-            static ALLOCATOR: Allocator = Allocator::new();
+            const ALLOCATOR: Allocator = Allocator::new();
 
             $(
                 // Make this `const` once `const_mut_refs` is stable for the platform-tools


### PR DESCRIPTION
### Problem

PR #126 added the ability to statically allocate memory on the heap reserved space. As noted in #136, there are a few caveats of using it:
* developers need to manually determine the memory offset for the allocation
* there is no compile time check to avoid memory overlaps if a wrong offset is used
* dynamic memory allocation is disabled

### Solution

This PR adds a `const_allocator` macro that combines the static allocation with the existing `BumpAllocator`. In summary, it calculates the offsets for the static allocations and then sets up the `BumpAllocator` with the remaining heap space.
```rust
pinocchio::const_allocator!({
    buffer: [u8; 5000],
    counter: u64,
    some_other_allocation: u32,
});
```

The allocations are available to the program under an `alloc` module generated by the macro:
```rust
let buffer: &mut [u8; 5000] = crate::alloc::buffer();
let counter: &mut u64 = crate::alloc::counter();
let some_other_allocation: &mut u32 = crate::alloc::some_other_allocation();
```

Programs can use the remaining heap space with the "standard" global allocator. The following code will work when using the `const_allocator`:
```rust
let mut dynamic_buffer: Vec<u8> = Vec::with_capacity(5000);
```

If the static allocation exceeds the available heap space, a compile time error is generated:
```
could not evaluate static initializer
the evaluated program panicked at 'Heap allocation overflow: The size of the
allocated memory exceeds the available heap space.'
```

The `const_allocator` is complementary to the `static_allocator` macro. The later gives all the control to the developer, while `const_allocator` provides the flexibility of static and dynamic allocations.

cc: @publicqi 