### PR TITLE
Add EpochRewards sysvar type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
  "solana-account-view",
  "solana-address",
  "solana-define-syscall",
+ "solana-hash",
  "solana-instruction-view",
  "solana-program-error",
 ]
@@ -113,6 +114,12 @@ name = "solana-define-syscall"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
+
+[[package]]
+name = "solana-hash"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5d48a6ee7b91fc7b998944ab026ed7b3e2fc8ee3bc58452644a86c2648152f"
 
 [[package]]
 name = "solana-instruction-view"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ pinocchio = { version = "0.9", default-features = false, path = "sdk" }
 solana-account-view = "1.0"
 solana-address = "2.0"
 solana-define-syscall = "4.0"
+solana-hash = "4.0"
 solana-instruction-view = "1.0"
 solana-program-error = "3.0"
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -23,13 +23,14 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 
 [features]
 alloc = ["solana-instruction-view?/slice-cpi"]
-copy = ["solana-account-view/copy", "solana-address/copy"]
+copy = ["solana-account-view/copy", "solana-address/copy", "solana-hash/copy"]
 cpi = ["dep:solana-instruction-view"]
 default = ["alloc"]
 
 [dependencies]
 solana-account-view = { workspace = true }
 solana-address = { workspace = true, features = ["syscalls"] }
+solana-hash = { workspace = true }
 solana-instruction-view = { workspace = true, features = ["cpi"], optional = true }
 solana-program-error = { workspace = true }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -258,6 +258,10 @@ pub use solana_address::Address;
 #[cfg(any(target_os = "solana", target_arch = "bpf"))]
 pub use solana_define_syscall::definitions as syscalls;
 
+// Re-export the `solana_hash` for downstream use.
+pub use solana_hash as hash;
+pub use solana_hash::Hash;
+
 // Re-export the `solana_instruction_view` for downstream use.
 #[cfg(feature = "cpi")]
 pub use {solana_instruction_view as instruction, solana_instruction_view::cpi};

--- a/sdk/src/sysvars/epoch_rewards.rs
+++ b/sdk/src/sysvars/epoch_rewards.rs
@@ -1,0 +1,50 @@
+use crate::{impl_sysvar_get, sysvars::Sysvar, Address, Hash};
+
+/// The ID of the epoch rewards sysvar.
+pub const EPOCH_REWARDS_ID: Address = Address::new_from_array([
+    6, 167, 213, 23, 24, 220, 63, 238, 2, 165, 88, 191, 131, 206, 102, 225, 68, 66, 42, 28, 52,
+    149, 11, 39, 193, 134, 155, 90, 156, 0, 0, 0,
+]);
+
+/// Epoch rewards sysvar
+#[repr(C)]
+#[cfg_attr(feature = "copy", derive(Copy))]
+#[derive(Debug, Default, Clone)]
+pub struct EpochRewards {
+    /// The starting block height of the rewards distribution in the current
+    /// epoch
+    pub distribution_starting_block_height: u64,
+
+    /// Number of partitions in the rewards distribution in the current epoch,
+    /// used to generate an EpochRewardsHasher
+    pub num_partitions: u64,
+
+    /// The blockhash of the parent block of the first block in the epoch, used
+    /// to seed an EpochRewardsHasher
+    pub parent_blockhash: Hash,
+
+    /// The total rewards points calculated for the current epoch, where points
+    /// equals the sum of (delegated stake * credits observed) for all
+    /// delegations
+    pub total_points: u128,
+
+    /// The total rewards calculated for the current epoch. This may be greater
+    /// than the total `distributed_rewards` at the end of the rewards period,
+    /// due to rounding and inability to deliver rewards smaller than 1 lamport.
+    pub total_rewards: u64,
+
+    /// The rewards currently distributed for the current epoch, in lamports
+    pub distributed_rewards: u64,
+
+    /// Whether the rewards period (including calculation and distribution) is
+    /// active
+    pub active: bool,
+}
+
+impl Sysvar for EpochRewards {
+    // SAFETY: upstream invariant: the sysvar data is created exclusively
+    // by the Solana runtime and serializes bool as 0x00 or 0x01, so the final
+    // `bool` field of `EpochRewards` can be re-aligned with padding and read
+    // directly without validation.
+    impl_sysvar_get!(EPOCH_REWARDS_ID, 15);
+}

--- a/sdk/src/sysvars/mod.rs
+++ b/sdk/src/sysvars/mod.rs
@@ -8,6 +8,7 @@ use crate::syscalls::sol_get_sysvar;
 use crate::{error::ProgramError, Address};
 
 pub mod clock;
+pub mod epoch_rewards;
 pub mod fees;
 pub mod instructions;
 pub mod rent;


### PR DESCRIPTION
This PR adds EpochRewards sysvar type. I copied it from solana-sdk. Not sure about `total_points` because it is `u128`. It will work with `get`, but if `from_account_info` is implemented it can cause UB. Probably it should be changed to [u8; 16].