### PR TITLE
Deprecate AccountInfo::realloc

### DIFF
--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -435,6 +435,7 @@ impl AccountInfo {
     /// referenced by `AccountInfo` fields. It should only be called for
     /// instances of `AccountInfo` that were created by the runtime and received
     /// in the `process_instruction` entrypoint of a program.
+    #[deprecated(since = "0.9.0", note = "Use AccountInfo::resize() instead")]
     pub fn realloc(&self, new_len: usize, zero_init: bool) -> Result<(), ProgramError> {
         let mut data = self.try_borrow_mut_data()?;
         let current_len = data.len();
@@ -505,6 +506,7 @@ impl AccountInfo {
     /// in the `process_instruction` entrypoint of a program.
     #[inline]
     pub fn resize(&self, new_len: usize) -> Result<(), ProgramError> {
+        #[allow(deprecated)]
         self.realloc(new_len, true)
     }
 


### PR DESCRIPTION
### Problem

Currently `realloc` offers the option to zero the account data or not when extending its size. This behaviour will be deprecated by the runtime and data will always be zeroed, so the `zero_init` parameter should not be used.

### Solution

Deprecate the `realloc` method and provide a `resize` one that always zeroes the account data when extending its size.