### PR TITLE
Improve program entrypoint

### DIFF
--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -393,9 +393,10 @@ pub unsafe fn deserialize<const MAX_ACCOUNTS: usize>(
     input = input.add(size_of::<u64>());
 
     let instruction_data = { from_raw_parts(input, instruction_data_len) };
+    let input = input.add(instruction_data_len);
 
     // program id
-    let program_id: &Pubkey = &*(input.add(instruction_data_len) as *const Pubkey);
+    let program_id: &Pubkey = &*(input as *const Pubkey);
 
     (program_id, processed, instruction_data)
 }


### PR DESCRIPTION
### Problem

The current program entrypoint does not translate to very efficient bytecode, as can be seen from an assembly implementation of entrypoint – e.g., cavey's [`asmr`](https://github.com/cavemanloverboy/asmr).

### Solution

Tweak the implementation to improve its efficiency, borrowing ideas from the assembly implementation (credits to @cavemanloverboy).

One key difference is that the entrypoint includes inlined code to parse accounts, which reduces the number of jumps required and therefore reduces CUs.

### Results

![image](https://github.com/user-attachments/assets/78eb4541-ae89-4e2e-ae23-fa03dbee0c9e)
