### PR TITLE
Improve sysvar get error handling

### DIFF
--- a/sdk/pinocchio/src/sysvars/mod.rs
+++ b/sdk/pinocchio/src/sysvars/mod.rs
@@ -11,7 +11,7 @@ pub mod fees;
 pub mod instructions;
 pub mod rent;
 
-/// Return value indicating that the  `offset + length` is greater than the length of
+/// Return value indicating that the `offset + length` is greater than the length of
 /// the sysvar data.
 //
 // Defined in the bpf loader as [`OFFSET_LENGTH_EXCEEDS_SYSVAR`](https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L172).
@@ -93,9 +93,9 @@ pub unsafe fn get_sysvar_unchecked(
         match result {
             crate::SUCCESS => Ok(()),
             OFFSET_LENGTH_EXCEEDS_SYSVAR => Err(ProgramError::InvalidArgument),
-            // An invalid sysvar id and unexpected errors are folded
-            // into `UnsupportedSysvar`.
-            SYSVAR_NOT_FOUND | _ => Err(ProgramError::UnsupportedSysvar),
+            SYSVAR_NOT_FOUND => Err(ProgramError::UnsupportedSysvar),
+            // Unexpected errors are folded into `UnsupportedSysvar`.
+            _ => Err(ProgramError::UnsupportedSysvar),
         }
     }
 


### PR DESCRIPTION
### Problem

Currently the implementation of `impl_sysvar_get` macro and `get_sysvar` return a `e.into()` when the syscall fails to return `SUCCESS`. This generates `ProgramError::Custom(_)` errors, although there are no custom errors associated with them.

### Solution

There are only [two](https://github.com/anza-xyz/agave/blob/master/programs/bpf_loader/src/syscalls/sysvar.rs#L228-L239) situations where a sysvar get will return an error code:
1. if you pass a wrong combination of length and offset, which tries to copy data outside the sysvar length
2. If you pass an invalid sysvar id

This PR updates the error handling to return a `ProgramError::InvalidArgument` for the first case and `ProgramError::UnsupportedSysvar` for the second.