### PR TITLE
log: Calculate maximum digits for `Log` implementation

### DIFF
--- a/sdk/log/crate/src/logger.rs
+++ b/sdk/log/crate/src/logger.rs
@@ -224,7 +224,7 @@ macro_rules! impl_log_for_unsigned_integer {
             #[inline]
             fn write_with_args(&self, buffer: &mut [MaybeUninit<u8>], args: &[Argument]) -> usize {
                 // The maximum number of digits that the type can have.
-                const MAX_DIGITS: usize = const { $type::MAX.ilog10() as usize + 1 };
+                const MAX_DIGITS: usize = $type::MAX.ilog10() as usize + 1;
 
                 if buffer.is_empty() {
                     return 0;


### PR DESCRIPTION
### Problem

Currently the `Log` implementation for unsigned integer types specify the maximum number of digits that a value can have manually.

### Solution

Simplify the implementation by calculating the value automatically:
```rust
const MAX_DIGITS: usize = const { <type>::MAX.ilog10() as usize + 1 };
```
This does not have a performance implication since `MAX_DIGITS` is calculated at compile time.

cc: @d0nutptr