### PR TITLE
pubkey: Optional bump parameter

### DIFF
--- a/sdk/pubkey/src/lib.rs
+++ b/sdk/pubkey/src/lib.rs
@@ -80,7 +80,7 @@ pub fn derive_address<const N: usize>(
     {
         let mut pda = MaybeUninit::<[u8; 32]>::uninit();
 
-        // SAFETY: `data` has `N + 2` elements initialized.
+        // SAFETY: `data` has `i + 2` elements initialized.
         unsafe {
             sol_sha256(
                 data.as_ptr() as *const u8,


### PR DESCRIPTION
### Problem

PR #192  added `derive_address` and `derive_address_const` helpers, both expect a `bump` value in addition to the seeds. While a `bump` value is generally used to ensure a valid PDA (off-curve) is generated, it is not a requirement – it is possible to have a valid PDA without a `bump` value.

### Solution

<del>This PR removes the individual `bump` parameter from `derive_address` and `derive_address_const`. When a `bump` value is used in the derivation, its value can be specified in the seeds array.</del>

This PR makes the individual `bump` parameter from `derive_address` and `derive_address_const` optional.