### PR TITLE
pinocchio: Add hint module

### DIFF
--- a/sdk/pinocchio/src/lib.rs
+++ b/sdk/pinocchio/src/lib.rs
@@ -264,3 +264,39 @@ pub const SUCCESS: u64 = 0;
 
 /// The result of a program execution.
 pub type ProgramResult = Result<(), program_error::ProgramError>;
+
+/// Module with functions to provide hints to the compiler about how code
+/// should be optimized.
+pub mod hint {
+    /// A "dummy" function with a hint to the compiler that it is unlikely to be
+    /// called.
+    ///
+    /// This function is used as a hint to the compiler to optimize other code paths
+    /// instead of the one where the function is used.
+    #[cold]
+    pub const fn cold_path() {}
+
+    /// Return the given `bool` value with a hint to the compiler that `true` is the
+    /// likely case.
+    #[inline(always)]
+    pub const fn likely(b: bool) -> bool {
+        if b {
+            true
+        } else {
+            cold_path();
+            false
+        }
+    }
+
+    /// Return a given `bool` value with a hint to the compiler that `false` is the
+    /// likely case.
+    #[inline(always)]
+    pub const fn unlikely(b: bool) -> bool {
+        if b {
+            cold_path();
+            true
+        } else {
+            false
+        }
+    }
+}


### PR DESCRIPTION
### Problem

It is possible to add hints to the compiler to help it optimize the code and save CUs – e.g., as it is used in [p-token](https://github.com/solana-program/token/pull/81).

### Solution

Add a new module `hint` with heper functions. This is similar to the experimental API from [`core::hint`](https://doc.rust-lang.org/core/hint/index.html).

Credits to @cavemanloverboy for this suggestion.