### PR TITLE
pinocchio: Add missing derives on bump allocator

### DIFF
--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -633,6 +633,7 @@ mod alloc {
     };
 
     /// The bump allocator used as the default rust heap when running programs.
+    #[derive(Clone, Copy, Debug)]
     pub struct BumpAllocator {
         pub start: usize,
         pub len: usize,


### PR DESCRIPTION
### Problem

In #228 lints for missing debug and copy derives were introduced. This currently generates a warning since the bump allocator is missing both.

### Solution

Add derives to `BumpAllocator`.