### PR TITLE
Add Custom Errors for Better Debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pinocchio_err"
+version = "0.1.0"
+dependencies = [
+ "pinocchio",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
     "programs/memo",
     "programs/system",
     "programs/token",
-    "programs/token-2022",
+    "programs/token-2022", "sdk/err",
     "sdk/log/crate",
     "sdk/log/macro",
     "sdk/pinocchio",

--- a/sdk/err/Cargo.toml
+++ b/sdk/err/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pinocchio_err"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lib]
+proc_macro = true
+
+[dependencies]
+pinocchio.workspace = true
+quote.workspace = true
+syn.workspace = true

--- a/sdk/err/src/lib.rs
+++ b/sdk/err/src/lib.rs
@@ -1,0 +1,62 @@
+use pinocchio::program_error::ProgramError;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput};
+
+/// Defines a custom error macro to create custom errors in pinocchio framework
+#[proc_macro_derive(ErrorCode, attributes(msg))]
+pub fn error_code(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let variants = if let Data::Enum(data_enum) = &input.data {
+        &data_enum.variants
+    } else {
+        return syn::Error::new_spanned(name, "ErrorCode can only be derived for enums")
+            .to_compile_error()
+            .into();
+    };
+
+    let match_arms = variants.iter().map(|variant| {
+        let variant_name = &variant.ident;
+        let msg = variant
+            .attrs
+            .iter()
+            .find(|attr| attr.path.is_ident("msg"))
+            .and_then(|attr| attr.parse_meta().ok())
+            .and_then(|meta| {
+                if let syn::Meta::NameValue(nv) = meta {
+                    if let syn::Lit::Str(lit) = nv.lit {
+                        return Some(lit);
+                    }
+                }
+                None
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "Variant `{}` must have a #[msg(\"...\")] attribute",
+                    variant_name
+                )
+            });
+        quote! {
+            Self::#variant_name => #msg,
+        }
+    });
+
+    let expanded = quote! {
+        impl #name {
+            pub fn message(&self) -> &str {
+                match self {
+                    #( #match_arms )*
+                }
+            }
+        }
+
+        impl From<#name> for ProgramError {
+            fn from(e: #name) -> Self {
+                ProgramError::Custom(e as u32)
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/sdk/pinocchio/src/program_error.rs
+++ b/sdk/pinocchio/src/program_error.rs
@@ -284,6 +284,38 @@ impl ToStr for ProgramError {
     }
 }
 
+/// Require function to check for invariants and error out using custom errors defined in the pinocchio-err crate
+/// Logs the message defined in the msg attribute of the custom error's variants before erroring out
+///
+/// *Arguments* :
+///
+/// `invariant`: The invariant that shouldn't be false
+///
+/// `error`: A variant of the custom error defined in your program, which derives the ErrorCode trait
+///
+/// **`Note`**: **This function cannot be used with the ProgramError enum, as it's only optimized for custom errors for now**
+#[macro_export]
+macro_rules! require {
+    ($invariant:expr, $error:expr $(,)?) => {
+        if !$invariant {
+            // If the error type has a `message()` function, call it.
+            // Otherwise, do nothing.
+            #[allow(unused_variables)]
+            {
+                if false {
+                    // just to scope-check type
+                } else {
+                    #[allow(unused_unsafe)]
+                    unsafe {
+                        $crate::msg!($error.message());
+                    }
+                }
+            }
+            return Err($error.into());
+        }
+    };
+}
+
 #[cfg(feature = "std")]
 impl core::fmt::Display for ProgramError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {


### PR DESCRIPTION
# Fixes #253

## Overview
This PR introduces **custom error definitions** and **enhanced logging** for program errors.  

Currently, when a custom error occurs, the output is not very informative:

<img width="808" height="46" alt="Current error output" src="https://github.com/user-attachments/assets/671b2378-7180-43fa-a457-ec7052f2c775" />

This lack of clarity increases debugging time for developers and can be particularly problematic when deployed on-chain.

---

## Problem
- Developers struggle to quickly identify the source of errors in their programs.
- Debugging on-chain contracts becomes time-consuming and error-prone.

---

## Solution
By defining custom errors and leveraging enhanced logging, this PR aims to **reduce debugging time significantly** for contracts built on Pinocchio.

---

## Implementation
1. **Define a custom error** in your program using the `pinocchio_err` crate:

<img width="597" height="174" alt="Custom error definition" src="https://github.com/user-attachments/assets/5edc6f96-be5a-4d27-8800-7d67cbc1096e" />

2. **Use the `require!` macro** from the `pinocchio` crate to return program errors:

<img width="634" height="301" alt="Using require macro" src="https://github.com/user-attachments/assets/a80a5899-bb1f-4c94-85c1-a15410ce1aa8" />

---

## Result
When a custom error occurs, the output becomes clear and actionable:

<img width="1581" height="137" alt="Improved error output" src="https://github.com/user-attachments/assets/f01c3aac-e7d1-4806-9c33-dd97d4bca393" />

This improvement helps developers quickly identify and resolve issues, making on-chain program debugging far more efficient.
