### PR TITLE
ci: Pin cargo-audit version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -71,7 +71,7 @@ runs:
       if: ${{ contains(inputs.components, 'audit') }}
       uses: taiki-e/cache-cargo-install-action@v2
       with:
-        tool: cargo-audit
+        tool: cargo-audit@0.21.2
 
     - name: Install 'cargo-hack'
       if: ${{ contains(inputs.components, 'hack') }}


### PR DESCRIPTION
### Problem

The newest version of cargo-audit requires Rust `1.85` but the workspace is using `1.84.1`. This prevents running CI: https://github.com/anza-xyz/pinocchio/actions/runs/19213573916/job/55479516273

### Solution

Pin the version to the last version that supports `1.84.1`.