### PR TITLE
refactor: extract byte operations into dedicated crate

### DIFF
--- a/programs/token-2022/src/instructions/approve.rs
+++ b/programs/token-2022/src/instructions/approve.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Approves a delegate.
 ///

--- a/programs/token-2022/src/instructions/approve_checked.rs
+++ b/programs/token-2022/src/instructions/approve_checked.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Approves a delegate.
 ///

--- a/programs/token-2022/src/instructions/burn.rs
+++ b/programs/token-2022/src/instructions/burn.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Burns tokens by removing them from an account.
 ///

--- a/programs/token-2022/src/instructions/burn_checked.rs
+++ b/programs/token-2022/src/instructions/burn_checked.rs
@@ -1,8 +1,8 @@
 use core::slice::from_raw_parts;
 
-use crate::{write_bytes, UNINIT_BYTE};
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     pubkey::Pubkey,

--- a/programs/token-2022/src/instructions/initialize_account_2.rs
+++ b/programs/token-2022/src/instructions/initialize_account_2.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     cpi::invoke,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Initialize a new Token Account.
 ///

--- a/programs/token-2022/src/instructions/initialize_account_3.rs
+++ b/programs/token-2022/src/instructions/initialize_account_3.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     cpi::invoke,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Initialize a new Token Account.
 ///

--- a/programs/token-2022/src/instructions/initialize_mint.rs
+++ b/programs/token-2022/src/instructions/initialize_mint.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     cpi::invoke,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Initialize a new mint.
 ///

--- a/programs/token-2022/src/instructions/initialize_mint_2.rs
+++ b/programs/token-2022/src/instructions/initialize_mint_2.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     cpi::invoke,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Initialize a new mint.
 ///

--- a/programs/token-2022/src/instructions/mint_to.rs
+++ b/programs/token-2022/src/instructions/mint_to.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Mints new tokens to an account.
 ///

--- a/programs/token-2022/src/instructions/mint_to_checked.rs
+++ b/programs/token-2022/src/instructions/mint_to_checked.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Mints new tokens to an account.
 ///

--- a/programs/token-2022/src/instructions/set_authority.rs
+++ b/programs/token-2022/src/instructions/set_authority.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 #[repr(u8)]
 #[derive(Clone, Copy)]

--- a/programs/token-2022/src/instructions/transfer.rs
+++ b/programs/token-2022/src/instructions/transfer.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Transfer Tokens from one Token Account to another.
 ///

--- a/programs/token-2022/src/instructions/transfer_checked.rs
+++ b/programs/token-2022/src/instructions/transfer_checked.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Transfer Tokens from one Token Account to another.
 ///

--- a/programs/token-2022/src/lib.rs
+++ b/programs/token-2022/src/lib.rs
@@ -4,14 +4,3 @@ pub mod instructions;
 pub mod state;
 
 pinocchio_pubkey::declare_id!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
-
-use core::mem::MaybeUninit;
-
-const UNINIT_BYTE: MaybeUninit<u8> = MaybeUninit::<u8>::uninit();
-
-#[inline(always)]
-fn write_bytes(destination: &mut [MaybeUninit<u8>], source: &[u8]) {
-    for (d, s) in destination.iter_mut().zip(source.iter()) {
-        d.write(*s);
-    }
-}

--- a/programs/token/src/instructions/approve.rs
+++ b/programs/token/src/instructions/approve.rs
@@ -2,12 +2,11 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Approves a delegate.
 ///

--- a/programs/token/src/instructions/approve_checked.rs
+++ b/programs/token/src/instructions/approve_checked.rs
@@ -2,12 +2,11 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Approves a delegate.
 ///

--- a/programs/token/src/instructions/burn.rs
+++ b/programs/token/src/instructions/burn.rs
@@ -2,12 +2,11 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Burns tokens by removing them from an account.
 ///

--- a/programs/token/src/instructions/burn_checked.rs
+++ b/programs/token/src/instructions/burn_checked.rs
@@ -1,8 +1,8 @@
 use core::slice::from_raw_parts;
 
-use crate::{write_bytes, UNINIT_BYTE};
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     ProgramResult,

--- a/programs/token/src/instructions/initialize_account_2.rs
+++ b/programs/token/src/instructions/initialize_account_2.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     cpi::invoke,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Initialize a new Token Account.
 ///

--- a/programs/token/src/instructions/initialize_account_3.rs
+++ b/programs/token/src/instructions/initialize_account_3.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     cpi::invoke,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Initialize a new Token Account.
 ///

--- a/programs/token/src/instructions/initialize_mint.rs
+++ b/programs/token/src/instructions/initialize_mint.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     cpi::invoke,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Initialize a new mint.
 ///

--- a/programs/token/src/instructions/initialize_mint_2.rs
+++ b/programs/token/src/instructions/initialize_mint_2.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     cpi::invoke,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Initialize a new mint.
 ///

--- a/programs/token/src/instructions/mint_to.rs
+++ b/programs/token/src/instructions/mint_to.rs
@@ -2,12 +2,11 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Mints new tokens to an account.
 ///

--- a/programs/token/src/instructions/mint_to_checked.rs
+++ b/programs/token/src/instructions/mint_to_checked.rs
@@ -2,12 +2,11 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Mints new tokens to an account.
 ///

--- a/programs/token/src/instructions/set_authority.rs
+++ b/programs/token/src/instructions/set_authority.rs
@@ -2,13 +2,12 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     pubkey::Pubkey,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 #[repr(u8)]
 #[derive(Clone, Copy)]

--- a/programs/token/src/instructions/transfer.rs
+++ b/programs/token/src/instructions/transfer.rs
@@ -2,12 +2,11 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Transfer tokens from one Token account to another.
 ///

--- a/programs/token/src/instructions/transfer_checked.rs
+++ b/programs/token/src/instructions/transfer_checked.rs
@@ -2,12 +2,11 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
+    bytes::{write_bytes, UNINIT_BYTE},
     instruction::{AccountMeta, Instruction, Signer},
     program::invoke_signed,
     ProgramResult,
 };
-
-use crate::{write_bytes, UNINIT_BYTE};
 
 /// Transfer Tokens from one Token Account to another.
 ///

--- a/programs/token/src/lib.rs
+++ b/programs/token/src/lib.rs
@@ -4,14 +4,3 @@ pub mod instructions;
 pub mod state;
 
 pinocchio_pubkey::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
-
-use core::mem::MaybeUninit;
-
-const UNINIT_BYTE: MaybeUninit<u8> = MaybeUninit::<u8>::uninit();
-
-#[inline(always)]
-fn write_bytes(destination: &mut [MaybeUninit<u8>], source: &[u8]) {
-    for (d, s) in destination.iter_mut().zip(source.iter()) {
-        d.write(*s);
-    }
-}

--- a/sdk/pinocchio/src/cpi.rs
+++ b/sdk/pinocchio/src/cpi.rs
@@ -488,8 +488,7 @@ pub fn set_return_data(data: &[u8]) {
 pub fn get_return_data() -> Option<ReturnData> {
     #[cfg(target_os = "solana")]
     {
-        const UNINIT_BYTE: core::mem::MaybeUninit<u8> = core::mem::MaybeUninit::<u8>::uninit();
-        let mut data = [UNINIT_BYTE; MAX_RETURN_DATA];
+        let mut data = [crate::bytes::UNINIT_BYTE; MAX_RETURN_DATA];
         let mut program_id = MaybeUninit::<Pubkey>::uninit();
 
         let size = unsafe {

--- a/sdk/pinocchio/src/lib.rs
+++ b/sdk/pinocchio/src/lib.rs
@@ -297,3 +297,15 @@ pub mod hint {
         }
     }
 }
+
+/// Module with utilities to work with byte arrays.
+pub mod bytes {
+    pub const UNINIT_BYTE: core::mem::MaybeUninit<u8> = core::mem::MaybeUninit::<u8>::uninit();
+
+    #[inline(always)]
+    pub fn write_bytes(destination: &mut [core::mem::MaybeUninit<u8>], source: &[u8]) {
+        for (d, s) in destination.iter_mut().zip(source.iter()) {
+            d.write(*s);
+        }
+    }
+}


### PR DESCRIPTION
### Problem

there is a part of functionality that is copy/pasted across Pinocchio crates

### Summary of Changes

- crate `bytes` module under `pinnochio` main crate
- extract 
```rust
const UNINIT_BYTE: core::mem::MaybeUninit<u8> // ...

fn write_bytes(destination: &mut [core::mem::MaybeUninit<u8>], source: &[u8]) {
  // ...
}
``` 
into this module
- import this functionality in `token` and `token-2022` crates instead of having duplicated logic

also will be used in one more crate - #284

cc @febo 