### PR TITLE
Add Compute Budget Program CPI helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "pinocchio-compute-budget"
+version = "0.1.0"
+dependencies = [
+ "pinocchio",
+ "pinocchio-pubkey",
+]
+
+[[package]]
 name = "pinocchio-log"
 version = "0.5.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "programs/associated-token-account",
+    "programs/compute-budget",
     "programs/memo",
     "programs/system",
     "programs/token",

--- a/programs/compute-budget/Cargo.toml
+++ b/programs/compute-budget/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pinocchio-compute-budget"
+description = "Pinocchio helpers to invoke Compute Budget program instructions"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+readme = "./README.md"
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+pinocchio = { workspace = true }
+pinocchio-pubkey = { workspace = true }

--- a/programs/compute-budget/README.md
+++ b/programs/compute-budget/README.md
@@ -1,0 +1,127 @@
+<p align="center">
+  <img alt="pinocchio-compute-budget" src="https://github.com/user-attachments/assets/4048fe96-9096-4441-85c3-5deffeb089a6" height="100"/>
+</p>
+<h3 align="center">
+  <code>pinocchio-compute-budget</code>
+</h3>
+<p align="center">
+  <a href="https://crates.io/crates/pinocchio-compute-budget"><img src="https://img.shields.io/crates/v/pinocchio-compute-budget?logo=rust" /></a>
+  <a href="https://docs.rs/pinocchio-compute-budget"><img src="https://img.shields.io/docsrs/pinocchio-compute-budget?logo=docsdotrs" /></a>
+</p>
+
+## Overview
+
+This crate contains [`pinocchio`](https://crates.io/crates/pinocchio) helpers to perform cross-program invocations (CPIs) for Compute Budget program instructions.
+
+The Compute Budget program allows you to optimize transaction costs and execution by controlling compute unit limits, setting priority fees, and requesting additional heap memory.
+
+Each instruction defines a `struct` with the required parameters. Once all values are set, you can call `invoke()` to perform the CPI.
+
+This is a `no_std` crate.
+
+> **Note:** The API defined in this crate is subject to change.
+
+## Instructions
+
+### SetComputeUnitLimit
+
+Set the maximum compute units for your transaction. Default is 1,400,000 CU. Setting a lower limit reduces fees when you know your program uses less.
+
+```rust
+use pinocchio_compute_budget::SetComputeUnitLimit;
+
+// Limit transaction to 50,000 compute units
+SetComputeUnitLimit {
+    units: 50_000,
+}.invoke()?;
+```
+
+### SetComputeUnitPrice
+
+Set the price in micro-lamports per compute unit. This is the **priority fee** mechanism - higher prices lead to faster confirmation.
+
+The total priority fee is calculated as: `priority_fee = compute_unit_limit * compute_unit_price`
+
+```rust
+use pinocchio_compute_budget::SetComputeUnitPrice;
+
+// Set priority fee to 10,000 micro-lamports per CU
+// With 50,000 CU limit above, this is 50,000 * 10,000 = 500,000,000 micro-lamports
+// = 0.5 lamports priority fee
+SetComputeUnitPrice {
+    micro_lamports: 10_000,
+}.invoke()?;
+```
+
+**Common price ranges:**
+- `0` - No priority (default, slowest)
+- `1-1,000` - Low priority
+- `1,000-10,000` - Medium priority  
+- `10,000-100,000` - High priority
+- `100,000+` - Very high priority (network congestion)
+
+### RequestHeapFrame
+
+Request additional heap memory beyond the default 32 KB, up to 256 KB total.
+
+```rust
+use pinocchio_compute_budget::RequestHeapFrame;
+
+// Request an additional 32 KB heap frame (64 KB total)
+RequestHeapFrame {
+    bytes: 32 * 1024,
+}.invoke()?;
+```
+
+**Requirements:**
+- Must be a multiple of 8 KB (8,192 bytes)
+- Maximum total heap is 256 KB
+
+## Complete Example
+
+Here's how to combine compute budget instructions in a program:
+
+```rust
+use pinocchio::{
+    account_info::AccountInfo,
+    entrypoint,
+    msg,
+    ProgramResult,
+    pubkey::Pubkey,
+};
+use pinocchio_compute_budget::{SetComputeUnitLimit, SetComputeUnitPrice};
+
+entrypoint!(process_instruction);
+
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    // Set compute limit to save on fees
+    SetComputeUnitLimit {
+        units: 50_000,
+    }.invoke()?;
+
+    // Set priority fee for fast confirmation
+    SetComputeUnitPrice {
+        micro_lamports: 10_000,
+    }.invoke()?;
+
+    // Your program logic here...
+    msg!("Processing with optimized compute budget!");
+
+    Ok(())
+}
+```
+
+## Why Use Compute Budget Instructions?
+
+1. **Save on Fees**: Set lower compute unit limits when you know your program uses less
+2. **Faster Confirmation**: Set priority fees to incentivize validators
+3. **More Heap**: Request additional heap for programs that need it
+4. **Better UX**: Faster transactions = better user experience
+
+## License
+
+The code is licensed under the [Apache License Version 2.0](../../LICENSE)

--- a/programs/compute-budget/src/instructions/mod.rs
+++ b/programs/compute-budget/src/instructions/mod.rs
@@ -1,0 +1,7 @@
+mod request_heap_frame;
+mod set_compute_unit_limit;
+mod set_compute_unit_price;
+
+pub use request_heap_frame::*;
+pub use set_compute_unit_limit::*;
+pub use set_compute_unit_price::*;

--- a/programs/compute-budget/src/instructions/request_heap_frame.rs
+++ b/programs/compute-budget/src/instructions/request_heap_frame.rs
@@ -1,0 +1,36 @@
+use pinocchio::{instruction::Instruction, program::invoke, ProgramResult};
+
+/// Request additional heap frame for the transaction.
+///
+/// Programs have 32 KB heap by default. Use this to request up to 256 KB total.
+/// Must be a multiple of 8 KB.
+///
+/// # Example
+///
+/// ```ignore
+/// RequestHeapFrame {
+///     bytes: 32 * 1024,  // Request additional 32 KB
+/// }.invoke()?;
+/// ```
+pub struct RequestHeapFrame {
+    /// Additional bytes to request (must be multiple of 8 KB).
+    pub bytes: u32,
+}
+
+impl RequestHeapFrame {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        
+        let mut instruction_data = [0u8; 5];
+        instruction_data[0] = 1;
+        instruction_data[1..5].copy_from_slice(&self.bytes.to_le_bytes());
+
+        let instruction = Instruction {
+            program_id: &crate::ID,
+            accounts: &[],
+            data: &instruction_data,
+        };
+
+        invoke(&instruction, &[])
+    }
+}

--- a/programs/compute-budget/src/instructions/set_compute_unit_limit.rs
+++ b/programs/compute-budget/src/instructions/set_compute_unit_limit.rs
@@ -1,0 +1,35 @@
+use pinocchio::{instruction::Instruction, program::invoke, ProgramResult};
+
+/// Set compute unit limit for a transaction.
+///
+/// Limits the compute units consumed. Useful to reduce fees when you know
+/// your program uses less than the default 1.4M CU limit.
+///
+/// # Example
+///
+/// ```ignore
+/// SetComputeUnitLimit {
+///     units: 50_000,
+/// }.invoke()?;
+/// ```
+pub struct SetComputeUnitLimit {
+    pub units: u32,
+}
+
+impl SetComputeUnitLimit {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+
+        let mut instruction_data = [0u8; 5];
+        instruction_data[0] = 2;
+        instruction_data[1..5].copy_from_slice(&self.units.to_le_bytes());
+
+        let instruction = Instruction {
+            program_id: &crate::ID,
+            accounts: &[],
+            data: &instruction_data,
+        };
+
+        invoke(&instruction, &[])
+    }
+}

--- a/programs/compute-budget/src/instructions/set_compute_unit_price.rs
+++ b/programs/compute-budget/src/instructions/set_compute_unit_price.rs
@@ -1,0 +1,36 @@
+use pinocchio::{instruction::Instruction, program::invoke, ProgramResult};
+
+/// Set compute unit price for transaction prioritization.
+///
+/// Higher prices lead to faster confirmation. Priority fee is calculated as:
+/// `priority_fee = compute_unit_limit * compute_unit_price`
+///
+/// # Example
+///
+/// ```ignore
+/// SetComputeUnitPrice {
+///     micro_lamports: 10_000,
+/// }.invoke()?;
+/// ```
+pub struct SetComputeUnitPrice {
+
+    pub micro_lamports: u64,
+}
+
+impl SetComputeUnitPrice {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+
+        let mut instruction_data = [0u8; 9];
+        instruction_data[0] = 3;
+        instruction_data[1..9].copy_from_slice(&self.micro_lamports.to_le_bytes());
+
+        let instruction = Instruction {
+            program_id: &crate::ID,
+            accounts: &[],
+            data: &instruction_data,
+        };
+
+        invoke(&instruction, &[])
+    }
+}

--- a/programs/compute-budget/src/lib.rs
+++ b/programs/compute-budget/src/lib.rs
@@ -1,0 +1,142 @@
+#![no_std]
+
+pub mod instructions;
+
+pinocchio_pubkey::declare_id!("ComputeBudget111111111111111111111111111111");
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+    use alloc::vec::Vec;
+
+
+    fn encode_instruction_data(discriminator: u8, data: &[u8]) -> Vec<u8> {
+        let mut result = Vec::new();
+        result.push(discriminator);
+        result.extend_from_slice(data);
+        result
+    }
+
+    #[test]
+    fn test_set_compute_unit_limit_discriminator() {
+        // Per official Solana docs:
+        // https://docs.rs/solana-compute-budget-interface/latest/
+        // SetComputeUnitLimit is variant #2 in the enum
+        //
+        // Verified discriminator: 2
+        let units = 50_000u32;
+
+        let expected = encode_instruction_data(2, &units.to_le_bytes());
+
+        assert_eq!(
+            expected[0], 2,
+            "SetComputeUnitLimit discriminator must be 2"
+        );
+        assert_eq!(
+            expected.len(),
+            5,
+            "Total length: 1 byte discriminator + 4 bytes u32"
+        );
+        assert_eq!(
+            &expected[1..5],
+            units.to_le_bytes(),
+            "u32 value must be little-endian"
+        );
+    }
+
+    #[test]
+    fn test_set_compute_unit_price_discriminator() {
+
+        let micro_lamports = 10_000u64;
+
+        let expected = encode_instruction_data(3, &micro_lamports.to_le_bytes());
+
+        assert_eq!(
+            expected[0], 3,
+            "SetComputeUnitPrice discriminator must be 3"
+        );
+        assert_eq!(
+            expected.len(),
+            9,
+            "Total length: 1 byte discriminator + 8 bytes u64"
+        );
+        assert_eq!(
+            &expected[1..9],
+            micro_lamports.to_le_bytes(),
+            "u64 value must be little-endian"
+        );
+    }
+
+    #[test]
+    fn test_request_heap_frame_discriminator() {
+
+        let bytes = 32 * 1024u32; // 32 KB
+
+        let expected = encode_instruction_data(1, &bytes.to_le_bytes());
+
+        assert_eq!(expected[0], 1, "RequestHeapFrame discriminator must be 1");
+        assert_eq!(
+            expected.len(),
+            5,
+            "Total length: 1 byte discriminator + 4 bytes u32"
+        );
+        assert_eq!(
+            &expected[1..5],
+            bytes.to_le_bytes(),
+            "u32 value must be little-endian"
+        );
+    }
+
+    #[test]
+    fn test_set_compute_unit_limit_various_values() {
+
+        let test_cases = [1_000u32, 50_000, 200_000, 1_400_000];
+
+        for units in test_cases {
+            let expected = encode_instruction_data(2, &units.to_le_bytes());
+            assert_eq!(expected[0], 2);
+            assert_eq!(&expected[1..5], units.to_le_bytes());
+        }
+    }
+
+    #[test]
+    fn test_set_compute_unit_price_various_values() {
+        
+        let test_cases = [
+            0u64,      // No priority
+            1_000,     // Low
+            10_000,    // Medium
+            100_000,   // High
+            1_000_000, // Very high
+        ];
+
+        for micro_lamports in test_cases {
+            let expected = encode_instruction_data(3, &micro_lamports.to_le_bytes());
+            assert_eq!(expected[0], 3);
+            assert_eq!(&expected[1..9], micro_lamports.to_le_bytes());
+        }
+    }
+
+    #[test]
+    fn test_request_heap_frame_multiples_of_8kb() {
+
+        let test_cases = [
+            8_192u32, // 8 KB
+            16_384,   // 16 KB
+            32_768,   // 32 KB
+            65_536,   // 64 KB
+        ];
+
+        for bytes in test_cases {
+            assert_eq!(bytes % 8_192, 0, "Heap request must be multiple of 8 KB");
+            let expected = encode_instruction_data(1, &bytes.to_le_bytes());
+            assert_eq!(expected[0], 1);
+            assert_eq!(&expected[1..5], bytes.to_le_bytes());
+        }
+    }
+
+    #[test]
+    fn test_compute_budget_program_id() {
+        assert_eq!(crate::ID.len(), 32);
+    }
+}


### PR DESCRIPTION
## Problem
Pinocchio lacks CPI helpers for the Compute Budget program. Developers must manually construct instruction bytes with discriminators, which is error-prone.



this provides the same convenience for priority fees that `pinocchio-system` provides for transfers.
cc @febo
