### PR TITLE
sdk: Remove deprecated code

### DIFF
--- a/sdk/src/entrypoint/lazy.rs
+++ b/sdk/src/entrypoint/lazy.rs
@@ -10,20 +10,6 @@ use crate::{
 
 /// Declare the lazy program entrypoint.
 ///
-/// Use the `lazy_program_entrypoint!` macro instead.
-#[deprecated(
-    since = "0.7.0",
-    note = "Use the `lazy_program_entrypoint!` macro instead"
-)]
-#[macro_export]
-macro_rules! lazy_entrypoint {
-    ( $process_instruction:expr ) => {
-        $crate::lazy_program_entrypoint!($process_instruction);
-    };
-}
-
-/// Declare the lazy program entrypoint.
-///
 /// This entrypoint is defined as *lazy* because it does not read the accounts upfront.
 /// Instead, it provides an [`InstructionContext`] to the access input information on demand.
 /// This is useful when the program needs more control over the compute units it uses.
@@ -111,20 +97,6 @@ pub struct InstructionContext {
 }
 
 impl InstructionContext {
-    /// Creates a new [`InstructionContext`] for the input buffer.
-    ///
-    /// The caller must ensure that the input buffer is valid, i.e., it represents
-    /// the program input parameters serialized by the SVM loader.
-    ///
-    /// This method is deprecated and will be removed in a future version. It is
-    /// missing the `unsafe` qualifier.
-    #[deprecated(since = "0.8.3", note = "Use `new_unchecked` instead")]
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    #[inline(always)]
-    pub fn new(input: *mut u8) -> Self {
-        unsafe { Self::new_unchecked(input) }
-    }
-
     /// Creates a new [`InstructionContext`] for the input buffer.
     ///
     /// # Safety

--- a/sdk/src/entrypoint/mod.rs
+++ b/sdk/src/entrypoint/mod.rs
@@ -27,17 +27,6 @@ pub const HEAP_START_ADDRESS: u64 = 0x300000000;
 /// Length of the heap memory region used for program heap.
 pub const HEAP_LENGTH: usize = 32 * 1024;
 
-#[deprecated(
-    since = "0.6.0",
-    note = "Use `ProgramResult` from the crate root instead"
-)]
-/// The result of a program execution.
-pub type ProgramResult = super::ProgramResult;
-
-#[deprecated(since = "0.6.0", note = "Use `SUCCESS` from the crate root instead")]
-/// Return value for a successful program execution.
-pub const SUCCESS: u64 = super::SUCCESS;
-
 /// Value used to indicate that a serialized account is not a duplicate.
 pub const NON_DUP_MARKER: u8 = u8::MAX;
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -243,9 +243,6 @@ extern crate alloc;
 pub mod entrypoint;
 pub mod sysvars;
 
-#[deprecated(since = "0.7.0", note = "Use the `entrypoint` module instead")]
-pub use entrypoint::lazy as lazy_entrypoint;
-
 // Re-export the `solana_account_view` for downstream use.
 pub use solana_account_view as account;
 pub use solana_account_view::AccountView;


### PR DESCRIPTION
### Problem

There a few bits of code that have been deprecated for a while. Since the next version will be a major release, they can be removed.

### Solution

Remove the deprecated code.