### PR TITLE
i fixed the unexpected cfg condition value: bpf-entrypoint

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -26,6 +26,7 @@ alloc = ["solana-instruction-view?/slice-cpi"]
 copy = ["solana-account-view/copy", "solana-address/copy"]
 cpi = ["dep:solana-instruction-view"]
 default = ["alloc"]
+bpf-entrypoint = [] 
 
 [dependencies]
 solana-account-view = { workspace = true }


### PR DESCRIPTION
## Summary
Adds the missing `bpf-entrypoint` feature to the SDK's Cargo.toml.

## Problem
The documentation examples in `src/entrypoint/mod.rs` and `src/entrypoint/lazy.rs` reference a `bpf-entrypoint` feature that didn't exist in Cargo.toml, causing doctest warnings:
```
warning: unexpected `cfg` condition value: `bpf-entrypoint`
  --> sdk/src/entrypoint/mod.rs:80:7
```

## Solution
Added `bpf-entrypoint = []` to the `[features]` section in `sdk/Cargo.toml`.

## Testing
- ✅ `cargo test --workspace` passes without warnings
- ✅ Doctests now compile successfully