### PR TITLE
sdk: Improve IntrospectedInstruction

### DIFF
--- a/sdk/src/sysvars/instructions.rs
+++ b/sdk/src/sysvars/instructions.rs
@@ -134,7 +134,7 @@ pub struct IntrospectedInstruction<'a> {
 }
 
 impl IntrospectedInstruction<'_> {
-    /// Create a new IntrospectedInstruction.
+    /// Create a new `IntrospectedInstruction`.
     ///
     /// # Safety
     ///


### PR DESCRIPTION
Made several improvements to the `IntrospectedInstruction` API, including:

1. Adding `num_account_metas(&self) -> usize` helper function
2. Created a private `new_unchecked(raw: *const u8) -> IntrospectedInstruction` function that is consumed internally to avoid having to expose `PhantomData` as a public field
3. Made `num_instructions` refer `usize` and removed all inline usize casts