### PR TITLE
Expose process_entrypoint function

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ use pinocchio::{
   AccountView,
   Address,
   entrypoint::process_entrypoint,
+  MAX_TX_ACCOUNTS,
   no_allocator,
   nostd_panic_handler,
-  ProgramResult
+  ProgramResult,
 };
 use solana_program_log::log;
 
@@ -122,7 +123,7 @@ pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
     }
 
     // Standard path: delegate to process_entrypoint
-    unsafe { process_entrypoint::<pinocchio::MAX_TX_ACCOUNTS>(input, process_instruction) }
+    unsafe { process_entrypoint::<MAX_TX_ACCOUNTS>(input, process_instruction) }
 }
 
 pub fn process_instruction(

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pub fn process_instruction(
   accounts: &[AccountView],
   instruction_data: &[u8],
 ) -> ProgramResult {
-  log!("Hello from my pinocchio program!");
+  log("Hello from my pinocchio program!");
   Ok(())
 }
 ```
@@ -117,7 +117,7 @@ pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
     // Fast path: check the number of accounts
     let num_accounts = unsafe { *(input as *const u64) };
     if num_accounts == 0 {
-        log!("Fast path - no accounts!");
+        log("Fast path - no accounts!");
         return 0;
     }
 
@@ -130,7 +130,7 @@ pub fn process_instruction(
   accounts: &[AccountView],
   instruction_data: &[u8],
 ) -> ProgramResult {
-  log!("Standard path");
+  log("Standard path");
   Ok(())
 }
 ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ default_panic_handler!();
 ```
 Any of these macros can be replaced by alternative implementations.
 
-📌 Custom Entrypoints with [`process_entrypoint`](https://docs.rs/pinocchio/latest/pinocchio/entrypoint/fn.process_entrypoint.html)
+📌 Custom entrypoints with [`process_entrypoint`](https://docs.rs/pinocchio/latest/pinocchio/entrypoint/fn.process_entrypoint.html)
 
 For programs that need maximum control over the entrypoint, `pinocchio` exposes the [`process_entrypoint`](https://docs.rs/pinocchio/latest/pinocchio/entrypoint/fn.process_entrypoint.html) function. This function is the same deserialization logic used internally by the `program_entrypoint!` macro, exposed as a public API and can be called directly from a custom entrypoint, allowing you to implement fast-path optimizations or custom pre-processing logic before falling back to standard input parsing.
 

--- a/scripts/setup/solana.dic
+++ b/scripts/setup/solana.dic
@@ -57,6 +57,7 @@ SVM
 BPF
 SBF
 inlined
+inlines
 CU/S
 borrowable
 callee

--- a/sdk/src/entrypoint/mod.rs
+++ b/sdk/src/entrypoint/mod.rs
@@ -184,7 +184,8 @@ pub unsafe fn process_entrypoint<const MAX_ACCOUNTS: usize>(
     // Create an array of uninitialized account views.
     let mut accounts = [UNINIT; MAX_ACCOUNTS];
 
-    let (program_id, count, instruction_data) = unsafe { deserialize::<MAX_ACCOUNTS>(input, &mut accounts) };
+    let (program_id, count, instruction_data) =
+        unsafe { deserialize::<MAX_ACCOUNTS>(input, &mut accounts) };
 
     // Call the program's entrypoint passing `count` account views; we know that
     // they are initialized so we cast the pointer to a slice of `[AccountView]`.

--- a/sdk/src/entrypoint/mod.rs
+++ b/sdk/src/entrypoint/mod.rs
@@ -15,7 +15,7 @@ use core::{
 
 use crate::{
     account::{AccountView, RuntimeAccount, MAX_PERMITTED_DATA_INCREASE},
-    Address, BPF_ALIGN_OF_U128, MAX_TX_ACCOUNTS, SUCCESS, ProgramResult
+    Address, ProgramResult, BPF_ALIGN_OF_U128, MAX_TX_ACCOUNTS, SUCCESS,
 };
 
 #[cfg(feature = "alloc")]

--- a/sdk/src/entrypoint/mod.rs
+++ b/sdk/src/entrypoint/mod.rs
@@ -161,26 +161,41 @@ macro_rules! program_entrypoint {
         /// Program entrypoint.
         #[no_mangle]
         pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
-            const UNINIT: core::mem::MaybeUninit<$crate::account::AccountView> =
-                core::mem::MaybeUninit::<$crate::account::AccountView>::uninit();
-            // Create an array of uninitialized account views.
-            let mut accounts = [UNINIT; $maximum];
-
-            let (program_id, count, instruction_data) =
-                $crate::entrypoint::deserialize::<$maximum>(input, &mut accounts);
-
-            // Call the program's entrypoint passing `count` account views; we know that
-            // they are initialized so we cast the pointer to a slice of `[AccountView]`.
-            match $process_instruction(
-                &program_id,
-                core::slice::from_raw_parts(accounts.as_ptr() as _, count),
-                &instruction_data,
-            ) {
-                Ok(()) => $crate::SUCCESS,
-                Err(error) => error.into(),
-            }
+            $crate::entrypoint::process_entrypoint::<$maximum>(input, $process_instruction)
         }
     };
+}
+
+/// Entrypoint deserialization.
+///
+/// This function inlines entrypoint deserialization for use in the `program_entrypoint!` macro.
+///
+/// # Safety
+///
+/// The caller must ensure that the `input` buffer is valid, i.e., it represents the program input
+/// parameters serialized by the SVM loader. Additionally, the `input` should last for the lifetime
+/// of the program execution since the returned values reference the `input`.
+#[inline(always)]
+pub unsafe fn process_entrypoint<const MAX_ACCOUNTS: usize>(
+    input: *mut u8,
+    process_instruction: fn(&Address, &[AccountView], &[u8]) -> crate::ProgramResult,
+) -> u64 {
+    const UNINIT: MaybeUninit<AccountView> = MaybeUninit::<AccountView>::uninit();
+    // Create an array of uninitialized account views.
+    let mut accounts = [UNINIT; MAX_ACCOUNTS];
+
+    let (program_id, count, instruction_data) = unsafe { deserialize::<MAX_ACCOUNTS>(input, &mut accounts) };
+
+    // Call the program's entrypoint passing `count` account views; we know that
+    // they are initialized so we cast the pointer to a slice of `[AccountView]`.
+    match process_instruction(
+        program_id,
+        unsafe { from_raw_parts(accounts.as_ptr() as _, count) },
+        instruction_data,
+    ) {
+        Ok(()) => crate::SUCCESS,
+        Err(error) => error.into(),
+    }
 }
 
 /// Align a pointer to the BPF alignment of [`u128`].

--- a/sdk/src/entrypoint/mod.rs
+++ b/sdk/src/entrypoint/mod.rs
@@ -15,7 +15,7 @@ use core::{
 
 use crate::{
     account::{AccountView, RuntimeAccount, MAX_PERMITTED_DATA_INCREASE},
-    Address, BPF_ALIGN_OF_U128, MAX_TX_ACCOUNTS,
+    Address, BPF_ALIGN_OF_U128, MAX_TX_ACCOUNTS, SUCCESS, ProgramResult
 };
 
 #[cfg(feature = "alloc")]
@@ -178,7 +178,7 @@ macro_rules! program_entrypoint {
 #[inline(always)]
 pub unsafe fn process_entrypoint<const MAX_ACCOUNTS: usize>(
     input: *mut u8,
-    process_instruction: fn(&Address, &[AccountView], &[u8]) -> crate::ProgramResult,
+    process_instruction: fn(&Address, &[AccountView], &[u8]) -> ProgramResult,
 ) -> u64 {
     const UNINIT: MaybeUninit<AccountView> = MaybeUninit::<AccountView>::uninit();
     // Create an array of uninitialized account views.
@@ -194,7 +194,7 @@ pub unsafe fn process_entrypoint<const MAX_ACCOUNTS: usize>(
         unsafe { from_raw_parts(accounts.as_ptr() as _, count) },
         instruction_data,
     ) {
-        Ok(()) => crate::SUCCESS,
+        Ok(()) => SUCCESS,
         Err(error) => error.into(),
     }
 }


### PR DESCRIPTION
This PR enables simpler fast-path optimization in Pinocchio program entrypoints without having to roll your own repro of the deserialization function. It exposes both a standard `entrypoint_deserialize` function consumed internally by the `program_entrypoint!` macro, as well as a `custom_program_entrypoint!` macro for convenience.