### PR TITLE
Optimize `write_bytes` function

### DIFF
--- a/programs/token-2022/src/lib.rs
+++ b/programs/token-2022/src/lib.rs
@@ -12,15 +12,11 @@ const UNINIT_BYTE: MaybeUninit<u8> = MaybeUninit::<u8>::uninit();
 #[inline(always)]
 fn write_bytes(destination: &mut [MaybeUninit<u8>], source: &[u8]) {
     let len = destination.len().min(source.len());
-    // SAFETY: 
+    // SAFETY:
     // - Both pointers have alignment 1.
     // - For valid (non-UB) references, the borrow checker guarantees no overlap.
     // - `len` is bounded by both slice lengths.
     unsafe {
-        core::ptr::copy_nonoverlapping(
-            source.as_ptr(),
-            destination.as_mut_ptr() as *mut u8,
-            len,
-        );
+        core::ptr::copy_nonoverlapping(source.as_ptr(), destination.as_mut_ptr() as *mut u8, len);
     }
 }

--- a/programs/token/src/lib.rs
+++ b/programs/token/src/lib.rs
@@ -12,15 +12,11 @@ const UNINIT_BYTE: MaybeUninit<u8> = MaybeUninit::<u8>::uninit();
 #[inline(always)]
 fn write_bytes(destination: &mut [MaybeUninit<u8>], source: &[u8]) {
     let len = destination.len().min(source.len());
-    // SAFETY: 
+    // SAFETY:
     // - Both pointers have alignment 1.
     // - For valid (non-UB) references, the borrow checker guarantees no overlap.
     // - `len` is bounded by both slice lengths.
     unsafe {
-        core::ptr::copy_nonoverlapping(
-            source.as_ptr(),
-            destination.as_mut_ptr() as *mut u8,
-            len,
-        );
+        core::ptr::copy_nonoverlapping(source.as_ptr(), destination.as_mut_ptr() as *mut u8, len);
     }
 }


### PR DESCRIPTION
We can save quite a few CUs spent on `write_bytes` by using `core::ptr::copy_nonoverlapping` instead of the previous looping approach. This is safe, as 

- we are aligned due to both pointers being `u8`
- both pointers have enough capacity by just picking the shorter one as the length
- we are non-overlapping thanks to rust's aliasing rules preventing this (unless the caller messes this up by using unsafe, however in that case it's on them)

So far, this func is used in the spl-token and token2022 crates. There, it gives the following benches for different CPIs (loop being how it's currently being done and copy being what this PR introduces):


## Token

| Operation | Loop | Copy | Saved | % |
|-----------|------|--------|-------|---|
| Transfer | 5851 | 5850 | **1** | 0.0% |
| TransferChecked | 7458 | 7457 | **1** | 0.0% |
| MintTo | 5745 | 5744 | **1** | 0.0% |
| Burn | 5961 | 5960 | **1** | 0.0% |
| Approve | 4112 | 4111 | **1** | 0.0% |
| Revoke | 3834 | 3834 | **0** | 0.0% |
| FreezeAccount | 5471 | 5470 | **1** | 0.0% |
| ThawAccount | 5471 | 5470 | **1** | 0.0% |
| CloseAccount | 4121 | 4120 | **1** | 0.0% |
| InitializeMint | 4366 | 4177 | **189** | 4.3% |
| InitializeMint2 | 4144 | 3993 | **151** | 3.6% |
| InitializeAccount | 5780 | 5779 | **1** | 0.0% |
| InitializeAccount2 | 5781 | 5615 | **166** | 2.9% |
| InitializeAccount3 | 5551 | 5417 | **134** | 2.4% |
| SetAuthority | 4331 | 4200 | **131** | 3.0% |

## Token-2022

| Operation | Loop | Copy | Saved | % |
|-----------|------|--------|-------|---|
| Transfer | 2503 | 2503 | **0** | 0.0% |
| TransferChecked | 2843 | 2844 | **-1** | -0.0% |
| MintTo | 2296 | 2296 | **0** | 0.0% |
| Burn | 2355 | 2355 | **0** | 0.0% |
| Approve | 2099 | 2100 | **-1** | -0.0% |
| Revoke | 1853 | 1853 | **0** | 0.0% |
| FreezeAccount | 2096 | 2096 | **0** | 0.0% |
| ThawAccount | 2094 | 2094 | **0** | 0.0% |
| CloseAccount | 2312 | 2311 | **1** | 0.0% |
| InitializeMint | 2498 | 2309 | **189** | 7.6% |
| InitializeMint2 | 2355 | 2202 | **153** | 6.5% |
| InitializeAccount | 2759 | 2760 | **-1** | -0.0% |
| InitializeAccount2 | 2749 | 2581 | **168** | 6.1% |
| InitializeAccount3 | 2600 | 2466 | **134** | 5.2% |
| SetAuthority | 2101 | 1970 | **131** | 6.2% |

The code for generating these benches can be found [here](https://github.com/cryptopapi997/pinocchio-write-bytes-cu-bench) , just run it once with `main` and once with this branch to get the two benches.