### PR TITLE
ci: integrate trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,6 @@ jobs:
   semver_check:
     name: Check Semver
     runs-on: ubuntu-latest
-    environment: prod
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -84,6 +83,7 @@ jobs:
   publish_release:
     name: Publish
     runs-on: ubuntu-latest
+    environment: prod
     needs: semver_check
     permissions:
       contents: write


### PR DESCRIPTION
### Summary of Changes

####  added `environment: prod` to semver_check

the pipeline flow is semver_check -> publish_release. if we add environments to both steps, we will need to approve twice

(let me know if you have any preference for the environment name)

#### remove `CARGO_REGISTRY_TOKEN` check

remove the token validation

#### switch to trusted publishing

use `rust-lang/crates-io-auth-action@v1` to get an ephemeral token and use it for the later publishing step


(btw, the environment isn't part of trusted publishing. we only use its approval mechanism to make the publishing process safer.)

---

Note:

set `Trusted Publishing` hook
- [x] pinocchio
- [x] pinocchio-token-2022
- [x] pinocchio-token
- [x] pinocchio-system
- [x] pinocchio-memo
- [x] pinocchio-associated-token-account 