### PR TITLE
refactor(entrypoint): reduce stack usage of macro from 2kb to 16b

### DIFF
--- a/sdk/src/entrypoint/mod.rs
+++ b/sdk/src/entrypoint/mod.rs
@@ -184,7 +184,7 @@ macro_rules! program_entrypoint {
                 [core::mem::MaybeUninit<$crate::account::AccountView>; $maximum],
             >(
                 $crate::entrypoint::HEAP_START_ADDRESS as usize
-                    + $crate::entrypoint::MAX_HEAP_LENGTH as usize
+                    + $crate::entrypoint::HEAP_LENGTH as usize
                     - ACCOUNTS_SIZE,
             );
 


### PR DESCRIPTION
### Problem

during the compilation `program_entrypoint` uses too much of stack memory

we ran into this issue during the implementation of [beethoven](https://github.com/blueshift-gg/beethoven)

```sh
RUSTFLAGS="-Csave-temps" cargo build-sbf --manifest-path program-test/Cargo.toml
```
returns:
```Error: Function entrypoint Stack offset of 4112 exceeded max offset of 4096 by 16 bytes, please minimize large stack variables.
Estimated function frame size: 4160 bytes. Exceeding the maximum stack offset may cause undefined behavior during execution.
```

### Proposed Solution

the accounts array is positioned at the end of the 256KB heap region (`HEAP_START_ADDRESS` + `MAX_HEAP_LENGTH` - `ACCOUNTS_SIZE`). This avoids conflicts with:
- the bump allocator (allocates forward from the start)
- manual allocations using `allocate_unchecked` from `no_allocator!` (use offset from start)

#### Stack Usage:
before: ~2KB (254 accounts x 8b)
after: 16b (pointers)

### Potential Issue

programs that don't allocate the full 256KB of heap should work the same.
programs heavily using heap space would need to account for the reserved accounts region

cc @febo 