### PR TITLE
docs(entrypoint): document inlining risk for entrypoint

### DIFF
--- a/sdk/src/entrypoint/mod.rs
+++ b/sdk/src/entrypoint/mod.rs
@@ -115,7 +115,7 @@ const STATIC_ACCOUNT_DATA: usize = size_of::<RuntimeAccount>() + MAX_PERMITTED_D
 /// In this case, it is not possible to use the `entrypoint` macro. Use the
 /// [`crate::program_entrypoint!`] macro instead and set up the allocator and panic handler
 /// manually.
-/// 
+///
 /// The compiler may inline the instruction handler (and its call tree) into the
 /// generated `entrypoint`, which can significantly increase the entrypoint stack frame. If your
 /// program has large instruction dispatch logic or builds sizable CPI account arrays, consider


### PR DESCRIPTION
# Problem

LTO can inline instruction handlers into entrypoint, inflating its stack frame and causing BPF stack overflows with large dispatch/CPI account arrays.

# Solution

Add documentation guidance recommending `#[inline(never)]` on instruction handlers to keep them out of the entrypoint stack frame if the case requires.