### PR TITLE
sdk: Remove unnecessary comments

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -329,8 +329,6 @@ extern crate alloc;
 pub mod entrypoint;
 pub mod sysvars;
 
-// Re-export the `solana_account_view` for downstream use.
-// Re-export the `solana_address` for downstream use.
 // Re-export the `solana_define_syscall` for downstream use.
 #[cfg(any(target_os = "solana", target_arch = "bpf"))]
 pub use solana_define_syscall::definitions as syscalls;


### PR DESCRIPTION
### Problem

After adding the formatting configuration to the repository, a couple of unnecessary comments were left over.

### Solution

Remove the unnecessary comments.