### PR TITLE
token-2022: Add mint close authority instruction

### DIFF
--- a/programs/token-2022/src/instructions/extensions/mint_close_authority.rs
+++ b/programs/token-2022/src/instructions/extensions/mint_close_authority.rs
@@ -25,6 +25,9 @@ pub struct InitializeMintCloseAuthority<'a, 'b> {
 
     /// Authority that must sign the `CloseAccount` instruction on a mint.
     pub close_authority: Option<&'b Address>,
+
+    // The token program.
+    pub token_program: &'b Address,
 }
 
 impl InitializeMintCloseAuthority<'_, '_> {
@@ -35,9 +38,8 @@ impl InitializeMintCloseAuthority<'_, '_> {
         let mut instruction_data = [UNINIT_BYTE; 34];
         let mut expected_data = 2;
 
-        // discriminator
         instruction_data[0].write(ExtensionDiscriminator::MintCloseAuthority as u8);
-        // close_authority
+
         if let Some(authority) = self.close_authority {
             instruction_data[1].write(1);
             write_bytes(&mut instruction_data[2..34], authority.as_ref());
@@ -48,9 +50,9 @@ impl InitializeMintCloseAuthority<'_, '_> {
 
         invoke(
             &InstructionView {
-                program_id: &crate::ID,
+                program_id: self.token_program,
                 accounts: &[InstructionAccount::writable(self.mint.address())],
-                // SAFETY: `instruction_data` was initialized.
+                // SAFETY: `instruction_data` was initialized for `expected_data` bytes.
                 data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, expected_data) },
             },
             &[self.mint],

--- a/programs/token-2022/src/instructions/extensions/mod.rs
+++ b/programs/token-2022/src/instructions/extensions/mod.rs
@@ -13,7 +13,7 @@ pub mod transfer_hook;
 #[repr(u8)]
 #[non_exhaustive]
 pub enum ExtensionDiscriminator {
-    MintCloseAuthority = 26,
+    MintCloseAuthority = 25,
     DefaultAccountState = 28,
     MemoTransfer = 30,
     InterestBearingMint = 33,


### PR DESCRIPTION
### Problem

Currently there are no instruction helpers for `MintCloseAuthority` extension.

### Solution

Add `MintCloseAuthority` extension discriminator and instruction.