### PR TITLE
token-2022: Add `InitializeNonTransferableMint` instruction

### DIFF
--- a/programs/token-2022/src/instructions/initialize_non_transferable_mint.rs
+++ b/programs/token-2022/src/instructions/initialize_non_transferable_mint.rs
@@ -1,0 +1,38 @@
+use {
+    solana_account_view::AccountView,
+    solana_address::Address,
+    solana_instruction_view::{cpi::invoke, InstructionAccount, InstructionView},
+    solana_program_error::ProgramResult,
+};
+
+/// Initialize the non transferable extension for the given mint account.
+///
+/// Fails if the account has already been initialized, so must be called
+/// before `InitializeMint`.
+///
+/// Accounts expected by this instruction:
+///
+///   0. `[writable]`  The mint account to initialize.
+pub struct InitializeNonTransferableMint<'a, 'b> {
+    /// The mint account to initialize.
+    pub mint: &'a AccountView,
+
+    /// The token program.
+    pub token_program: &'b Address,
+}
+
+impl InitializeNonTransferableMint<'_, '_> {
+    pub const DISCRIMINATOR: u8 = 32;
+
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        invoke(
+            &InstructionView {
+                program_id: self.token_program,
+                accounts: &[InstructionAccount::writable(self.mint.address())],
+                data: &[Self::DISCRIMINATOR],
+            },
+            &[self.mint],
+        )
+    }
+}

--- a/programs/token-2022/src/instructions/mod.rs
+++ b/programs/token-2022/src/instructions/mod.rs
@@ -12,6 +12,7 @@ mod initialize_mint;
 mod initialize_mint_2;
 mod initialize_multisig;
 mod initialize_multisig_2;
+mod initialize_non_transferable_mint;
 mod mint_to;
 mod mint_to_checked;
 mod revoke;
@@ -25,6 +26,6 @@ pub use {
     approve::*, approve_checked::*, burn::*, burn_checked::*, close_account::*, extensions::*,
     freeze_account::*, initialize_account::*, initialize_account_2::*, initialize_account_3::*,
     initialize_mint::*, initialize_mint_2::*, initialize_multisig::*, initialize_multisig_2::*,
-    mint_to::*, mint_to_checked::*, revoke::*, set_authority::*, sync_native::*, thaw_account::*,
-    transfer::*, transfer_checked::*,
+    initialize_non_transferable_mint::*, mint_to::*, mint_to_checked::*, revoke::*,
+    set_authority::*, sync_native::*, thaw_account::*, transfer::*, transfer_checked::*,
 };


### PR DESCRIPTION
### Problem

Currently there is no `InitializeNonTransferableMint` instruction.

### Solution

Add `InitializeNonTransferableMint` instruction.