### PR TITLE
feat: Add ZK ElGamal Proof program

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ on:
           - programs/system
           - programs/token
           - programs/token-2022
+          - programs/zk-elgamal-proof
           - sdk
       level:
         description: Level

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pinocchio-zk-elgamal-proof"
+version = "0.1.0"
+dependencies = [
+ "solana-account-view",
+ "solana-address",
+ "solana-instruction-view",
+ "solana-program-error",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "programs/system",
     "programs/token",
     "programs/token-2022",
+    "programs/zk-elgamal-proof",
     "sdk",
 ]
 

--- a/programs/zk-elgamal-proof/Cargo.toml
+++ b/programs/zk-elgamal-proof/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "pinocchio-zk-elgamal-proof"
+description = "Pinocchio helpers to invoke Zk ElGamal Proof program instructions"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+readme = "./README.md"
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+solana-account-view = { workspace = true }
+solana-address = { workspace = true, features = ["decode"] }
+solana-instruction-view = { workspace = true, features = ["cpi"] }
+solana-program-error = { workspace = true }

--- a/programs/zk-elgamal-proof/README.md
+++ b/programs/zk-elgamal-proof/README.md
@@ -1,0 +1,51 @@
+<p align="center">
+ <img alt="pinocchio-zk-elgamal-proof" src="https://github.com/user-attachments/assets/4048fe96-9096-4441-85c3-5deffeb089a6" height="100"/>
+</p>
+<h3 align="center">
+  <code>pinocchio-zk-elgamal-proof</code>
+</h3>
+<p align="center">
+  <a href="https://crates.io/crates/pinocchio-zk-elgamal-proof"><img src="https://img.shields.io/crates/v/pinocchio-zk-elgamal-proof?logo=rust" /></a>
+  <a href="https://docs.rs/pinocchio-zk-elgamal-proof"><img src="https://img.shields.io/docsrs/pinocchio-zk-elgamal-proof?logo=docsdotrs" /></a>
+</p>
+
+## Overview
+
+This crate contains [`pinocchio`](https://crates.io/crates/pinocchio) helpers to perform cross-program invocations (CPIs) for [ZK ElGamal Proof](https://github.com/solana-program/zk-elgamal-proof) program instructions.
+
+Each instruction defines a `struct` with the accounts and parameters required. Once all values are set, you can call directly `invoke` or `invoke_signed` to perform the CPI.
+
+This is a `no_std` crate.
+
+> **Note:** The API defined in this crate is subject to change.
+
+## Getting Started
+
+From your project folder:
+
+```bash
+cargo add pinocchio-zk-elgamal-proof
+```
+
+This will add the `pinocchio-zk-elgamal-proof` dependency to your `Cargo.toml` file.
+
+## Examples
+
+Verify a public key validity with a context state and a proof data array:
+
+```rust
+// This example assumes that instruction receives writable `context_state_account` account
+// and `context_state_authority` account.
+VerifyPubkeyValidity {
+    context_state_info: Some(ContextStateInfo {
+        context_state_account,
+        context_state_authority,
+    }),
+    proof: Proof::Data(proof_data),
+}
+.invoke()?;
+```
+
+## License
+
+The code is licensed under the [Apache License Version 2.0](../LICENSE)

--- a/programs/zk-elgamal-proof/src/instructions/close_context_state.rs
+++ b/programs/zk-elgamal-proof/src/instructions/close_context_state.rs
@@ -1,0 +1,57 @@
+use {
+    crate::ContextStateInfo,
+    solana_account_view::AccountView,
+    solana_instruction_view::{
+        cpi::{invoke_signed, Signer},
+        InstructionAccount, InstructionView,
+    },
+    solana_program_error::ProgramResult,
+};
+
+/// Close a zero-knowledge proof context state.
+///
+/// Accounts expected by this instruction:
+///
+///   0. `[writable]` The proof context account to close
+///   1. `[writable]` The destination account for lamports
+///   2. `[signer]` The context account's owner
+pub struct CloseContextState<'a, 'b> {
+    /// Context state to close
+    pub context_state_info: ContextStateInfo<'a>,
+    /// Destination account for lamports
+    pub destination_account: &'b AccountView,
+}
+
+impl CloseContextState<'_, '_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let instruction_accounts: [InstructionAccount; 3] = [
+            InstructionAccount::writable(self.context_state_info.context_state_account.address()),
+            InstructionAccount::writable(self.destination_account.address()),
+            InstructionAccount::readonly_signer(
+                self.context_state_info.context_state_authority.address(),
+            ),
+        ];
+
+        let instruction = InstructionView {
+            program_id: &crate::ID,
+            accounts: &instruction_accounts,
+            data: &[0],
+        };
+
+        invoke_signed(
+            &instruction,
+            &[
+                self.context_state_info.context_state_account,
+                self.destination_account,
+                self.context_state_info.context_state_authority,
+            ],
+            signers,
+        )
+    }
+}

--- a/programs/zk-elgamal-proof/src/instructions/mod.rs
+++ b/programs/zk-elgamal-proof/src/instructions/mod.rs
@@ -1,0 +1,16 @@
+mod close_context_state;
+mod verify_batched_grouped_ciphertext_validity;
+mod verify_batched_range_proof;
+mod verify_ciphertext_ciphertext_equality;
+mod verify_ciphertext_commitment_equality;
+mod verify_grouped_ciphertext_validity;
+mod verify_percentage_with_cap;
+mod verify_pubkey_validity;
+mod verify_zero_ciphertext;
+
+pub use {
+    close_context_state::*, verify_batched_grouped_ciphertext_validity::*,
+    verify_batched_range_proof::*, verify_ciphertext_ciphertext_equality::*,
+    verify_ciphertext_commitment_equality::*, verify_grouped_ciphertext_validity::*,
+    verify_percentage_with_cap::*, verify_pubkey_validity::*, verify_zero_ciphertext::*,
+};

--- a/programs/zk-elgamal-proof/src/instructions/verify_batched_grouped_ciphertext_validity.rs
+++ b/programs/zk-elgamal-proof/src/instructions/verify_batched_grouped_ciphertext_validity.rs
@@ -1,0 +1,26 @@
+use crate::{
+    create_instruction_struct, BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_FULL_LEN,
+    BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_FULL_LEN,
+};
+
+create_instruction_struct!(
+    DOC_MAIN = "Verify a batched grouped-ciphertext with 2 handles validity proof.",
+    DOC_AUX = "A batched grouped-ciphertext validity proof certifies the validity of two grouped \
+               ElGamal ciphertext that are encrypted using the same set of ElGamal public keys. A \
+               batched grouped-ciphertext validity proof is shorter and more efficient than two \
+               individual grouped-ciphertext validity proofs.",
+    INSTRUCTION_NAME = VerifyBatchedGroupedCiphertext2HandlesValidity,
+    DISCRIMINATOR = 10,
+    PROOF_LEN = BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_FULL_LEN
+);
+
+create_instruction_struct!(
+    DOC_MAIN = "Verify a batched grouped-ciphertext with 3 handles validity proof.",
+    DOC_AUX = "A batched grouped-ciphertext validity proof certifies the validity of two grouped \
+               ElGamal ciphertext that are encrypted using the same set of ElGamal public keys. A \
+               batched grouped-ciphertext validity proof is shorter and more efficient than two \
+               individual grouped-ciphertext validity proofs.",
+    INSTRUCTION_NAME = VerifyBatchedGroupedCiphertext3HandlesValidity,
+    DISCRIMINATOR = 12,
+    PROOF_LEN = BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_FULL_LEN
+);

--- a/programs/zk-elgamal-proof/src/instructions/verify_batched_range_proof.rs
+++ b/programs/zk-elgamal-proof/src/instructions/verify_batched_range_proof.rs
@@ -1,0 +1,52 @@
+use crate::{
+    create_instruction_struct, RANGE_PROOF_U128_FULL_LEN, RANGE_PROOF_U256_FULL_LEN,
+    RANGE_PROOF_U64_FULL_LEN,
+};
+
+create_instruction_struct!(
+    DOC_MAIN = "Verify a 64-bit batched range proof.",
+    DOC_AUX = "A batched range proof is defined with respect to a sequence of Pedersen \
+               commitments `[C_1, ..., C_N]` and bit-lengths `[n_1, ..., n_N]`. It certifies that \
+               each commitment `C_i` is a commitment to a positive number of bit-length `n_i`. \
+               Batch verifying range proofs is more efficient than verifying independent range \
+               proofs on commitments `C_1, ..., C_N` separately.
+
+The bit-length of a batched range proof specifies the sum of the individual bit-lengths `n_1, ..., \
+               n_N`. For example, this instruction can be used to certify that two commitments \
+               `C_1` and `C_2` each hold positive 32-bit numbers.",
+    INSTRUCTION_NAME = VerifyBatchedRangeProofU64,
+    DISCRIMINATOR = 6,
+    PROOF_LEN = RANGE_PROOF_U64_FULL_LEN
+);
+
+create_instruction_struct!(
+    DOC_MAIN = "Verify a 128-bit batched range proof.",
+    DOC_AUX = "A batched range proof is defined with respect to a sequence of Pedersen \
+               commitments `[C_1, ..., C_N]` and bit-lengths `[n_1, ..., n_N]`. It certifies that \
+               each commitment `C_i` is a commitment to a positive number of bit-length `n_i`. \
+               Batch verifying range proofs is more efficient than verifying independent range \
+               proofs on commitments `C_1, ..., C_N` separately.
+
+The bit-length of a batched range proof specifies the sum of the individual bit-lengths `n_1, ..., \
+               n_N`. For example, this instruction can be used to certify that two commitments \
+               `C_1` and `C_2` each hold positive 64-bit numbers.",
+    INSTRUCTION_NAME = VerifyBatchedRangeProofU128,
+    DISCRIMINATOR = 7,
+    PROOF_LEN = RANGE_PROOF_U128_FULL_LEN
+);
+
+create_instruction_struct!(
+    DOC_MAIN = "Verify a 256-bit batched range proof.",
+    DOC_AUX = "A batched range proof is defined with respect to a sequence of Pedersen \
+               commitments `[C_1, ..., C_N]` and bit-lengths `[n_1, ..., n_N]`. It certifies that \
+               each commitment `C_i` is a commitment to a positive number of bit-length `n_i`. \
+               Batch verifying range proofs is more efficient than verifying independent range \
+               proofs on commitments `C_1, ..., C_N` separately.
+
+The bit-length of a batched range proof specifies the sum of the individual bit-lengths `n_1, ..., \
+               n_N`. For example, this instruction can be used to certify that four commitments \
+               `[C_1, C_2, C_3, C_4]` each hold positive 64-bit numbers.",
+    INSTRUCTION_NAME = VerifyBatchedRangeProofU256,
+    DISCRIMINATOR = 8,
+    PROOF_LEN = RANGE_PROOF_U256_FULL_LEN
+);

--- a/programs/zk-elgamal-proof/src/instructions/verify_ciphertext_ciphertext_equality.rs
+++ b/programs/zk-elgamal-proof/src/instructions/verify_ciphertext_ciphertext_equality.rs
@@ -1,0 +1,10 @@
+use crate::{create_instruction_struct, CIPHERTEXT_CIPHERTEXT_EQUALITY_PROOF_FULL_LEN};
+
+create_instruction_struct!(
+    DOC_MAIN = "Verify a ciphertext-ciphertext equality proof.",
+    DOC_AUX = "A ciphertext-ciphertext equality proof certifies that two ElGamal ciphertexts \
+               encrypt the same message.",
+    INSTRUCTION_NAME = VerifyCiphertextCiphertextEquality,
+    DISCRIMINATOR = 2,
+    PROOF_LEN = CIPHERTEXT_CIPHERTEXT_EQUALITY_PROOF_FULL_LEN
+);

--- a/programs/zk-elgamal-proof/src/instructions/verify_ciphertext_commitment_equality.rs
+++ b/programs/zk-elgamal-proof/src/instructions/verify_ciphertext_commitment_equality.rs
@@ -1,0 +1,10 @@
+use crate::{create_instruction_struct, CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_FULL_LEN};
+
+create_instruction_struct!(
+    DOC_MAIN = "Verify a ciphertext-commitment equality proof.",
+    DOC_AUX = "A ciphertext-commitment equality proof certifies that an ElGamal ciphertext and a \
+               Pedersen commitment encrypt/encode the same message.",
+    INSTRUCTION_NAME = VerifyCiphertextCommitmentEquality,
+    DISCRIMINATOR = 3,
+    PROOF_LEN = CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_FULL_LEN
+);

--- a/programs/zk-elgamal-proof/src/instructions/verify_grouped_ciphertext_validity.rs
+++ b/programs/zk-elgamal-proof/src/instructions/verify_grouped_ciphertext_validity.rs
@@ -1,0 +1,24 @@
+use crate::{
+    create_instruction_struct, GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_FULL_LEN,
+    GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_FULL_LEN,
+};
+
+create_instruction_struct!(
+    DOC_MAIN = "Verify a grouped-ciphertext with 2 handles validity proof.",
+    DOC_AUX = "A grouped-ciphertext validity proof certifies that a grouped ElGamal ciphertext is \
+               well-defined, i.e. the ciphertext can be decrypted by private keys associated with \
+               its decryption handles.",
+    INSTRUCTION_NAME = VerifyGroupedCiphertext2HandlesValidity,
+    DISCRIMINATOR = 9,
+    PROOF_LEN = GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_FULL_LEN
+);
+
+create_instruction_struct!(
+    DOC_MAIN = "Verify a grouped-ciphertext with 3 handles validity proof.",
+    DOC_AUX = "A grouped-ciphertext validity proof certifies that a grouped ElGamal ciphertext is \
+               well-defined, i.e. the ciphertext can be decrypted by private keys associated with \
+               its decryption handles.",
+    INSTRUCTION_NAME = VerifyGroupedCiphertext3HandlesValidity,
+    DISCRIMINATOR = 11,
+    PROOF_LEN = GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_FULL_LEN
+);

--- a/programs/zk-elgamal-proof/src/instructions/verify_percentage_with_cap.rs
+++ b/programs/zk-elgamal-proof/src/instructions/verify_percentage_with_cap.rs
@@ -1,0 +1,10 @@
+use crate::{create_instruction_struct, PERCENTAGE_WITH_CAP_PROOF_FULL_LEN};
+
+create_instruction_struct!(
+    DOC_MAIN = "Verify a percentage-with-cap proof.",
+    DOC_AUX = "A percentage-with-cap proof certifies that a tuple of Pedersen commitments satisfy \
+               a percentage relation.",
+    INSTRUCTION_NAME = VerifyPercentageWithCap,
+    DISCRIMINATOR = 5,
+    PROOF_LEN = PERCENTAGE_WITH_CAP_PROOF_FULL_LEN
+);

--- a/programs/zk-elgamal-proof/src/instructions/verify_pubkey_validity.rs
+++ b/programs/zk-elgamal-proof/src/instructions/verify_pubkey_validity.rs
@@ -1,0 +1,10 @@
+use crate::{create_instruction_struct, PUBKEY_VALIDITY_PROOF_FULL_LEN};
+
+create_instruction_struct!(
+    DOC_MAIN = "Verify a public key validity zero-knowledge proof.",
+    DOC_AUX = "A public key validity proof certifies that an ElGamal public key is well-formed \
+               and the prover knows the corresponding secret key.",
+    INSTRUCTION_NAME = VerifyPubkeyValidity,
+    DISCRIMINATOR = 4,
+    PROOF_LEN = PUBKEY_VALIDITY_PROOF_FULL_LEN
+);

--- a/programs/zk-elgamal-proof/src/instructions/verify_zero_ciphertext.rs
+++ b/programs/zk-elgamal-proof/src/instructions/verify_zero_ciphertext.rs
@@ -1,0 +1,10 @@
+use crate::{create_instruction_struct, ZERO_CIPHERTEXT_PROOF_FULL_LEN};
+
+create_instruction_struct!(
+    DOC_MAIN = "Verify a zero-ciphertext proof.",
+    DOC_AUX =
+        "A zero-ciphertext proof certifies that an ElGamal ciphertext encrypts the value zero.",
+    INSTRUCTION_NAME = VerifyZeroCiphertext,
+    DISCRIMINATOR = 1,
+    PROOF_LEN = ZERO_CIPHERTEXT_PROOF_FULL_LEN
+);

--- a/programs/zk-elgamal-proof/src/lib.rs
+++ b/programs/zk-elgamal-proof/src/lib.rs
@@ -1,0 +1,238 @@
+#![no_std]
+
+pub mod instructions;
+
+use {
+    core::mem::MaybeUninit,
+    solana_account_view::AccountView,
+    solana_instruction_view::{cpi::invoke, InstructionAccount, InstructionView},
+    solana_program_error::ProgramResult,
+};
+
+solana_address::declare_id!("ZkE1Gama1Proof11111111111111111111111111111");
+
+/// Byte length of a zero-ciphertext proof with context
+pub const ZERO_CIPHERTEXT_PROOF_FULL_LEN: usize = 96 + 96; // 96 for context + 96 for proof
+
+/// Byte length of a ciphertext-ciphertext equality proof with context
+pub const CIPHERTEXT_CIPHERTEXT_EQUALITY_PROOF_FULL_LEN: usize = 192 + 224; // 192 for context + 224 for proof
+
+/// Byte length of a ciphertext-commitment equality proof with context
+pub const CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_FULL_LEN: usize = 128 + 192; // 128 for context + 192 for proof
+
+/// Byte length of a public key validity proof with context
+pub const PUBKEY_VALIDITY_PROOF_FULL_LEN: usize = 32 + 64; // 32 for context + 64 for proof
+
+/// Byte length of a percentage with cap proof with context
+pub const PERCENTAGE_WITH_CAP_PROOF_FULL_LEN: usize = 104 + 256; // 104 for context + 256 for proof
+
+/// Byte length of a range proof for an unsigned 64-bit number with context
+pub const RANGE_PROOF_U64_FULL_LEN: usize = 264 + 672; // 264 for context + 672 for proof
+
+/// Byte length of a range proof for an unsigned 128-bit number with context
+pub const RANGE_PROOF_U128_FULL_LEN: usize = 264 + 736; // 264 for context + 736 for proof
+
+/// Byte length of a range proof for an unsigned 256-bit number with context
+pub const RANGE_PROOF_U256_FULL_LEN: usize = 264 + 800; // 264 for context + 800 for proof
+
+/// Byte length of a grouped ciphertext for 2 handles validity proof with
+/// context
+pub const GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_FULL_LEN: usize = 160 + 160; // 160 for context + 160 for proof
+
+/// Byte length of a grouped ciphertext for 3 handles validity proof with
+/// context
+pub const GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_FULL_LEN: usize = 224 + 192; // 224 for context + 192 for proof
+
+/// Byte length of a batched grouped ciphertext for 2 handles validity proof
+/// with context
+pub const BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_FULL_LEN: usize = 256 + 160; // 256 for context + 160 for proof
+
+/// Byte length of a batched grouped ciphertext for 3 handles validity proof
+/// with context
+pub const BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_FULL_LEN: usize = 352 + 192; // 352 for context + 192 for proof
+
+const UNINIT_BYTE: MaybeUninit<u8> = MaybeUninit::<u8>::uninit();
+
+#[inline(always)]
+fn write_bytes(destination: &mut [MaybeUninit<u8>], source: &[u8]) {
+    let len = destination.len().min(source.len());
+    // SAFETY:
+    // - Both pointers have alignment 1.
+    // - For valid (non-UB) references, the borrow checker guarantees no overlap.
+    // - `len` is bounded by both slice lengths.
+    unsafe {
+        core::ptr::copy_nonoverlapping(source.as_ptr(), destination.as_mut_ptr() as *mut u8, len);
+    }
+}
+
+/// An enum that represents a proof.
+///
+/// It can contain two types of proofs:
+///
+/// 1. A reference to an account that contains a proof. The `offset` field
+///    specifies where in the account the proof is located.
+/// 2. A proof stored in a byte array of size `PROOF_LEN`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Proof<'a, const PROOF_LEN: usize> {
+    Account {
+        account: &'a AccountView,
+        offset: u32,
+    },
+    Data(&'a [u8; PROOF_LEN]),
+}
+
+/// A struct that holds references to the context state account and authority.
+///
+/// It is used to provide information about the context state when invoking an
+/// instruction.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ContextStateInfo<'a> {
+    pub context_state_account: &'a AccountView,
+    pub context_state_authority: &'a AccountView,
+}
+
+macro_rules! create_instruction_struct {
+    (
+        DOC_MAIN = $doc_main:literal,
+        DOC_AUX = $doc_aux:literal,
+        INSTRUCTION_NAME = $name:ident,
+        DISCRIMINATOR = $discriminator:expr,
+        PROOF_LEN = $proof_len:expr
+    ) => {
+        #[doc = $doc_main]
+        ///
+        #[doc = $doc_aux]
+        ///
+        /// Accounts expected by this instruction:
+        ///
+        ///   There are four ways to structure the accounts, depending on whether the
+        ///   proof is provided as instruction data or in a separate account, and
+        ///   whether a proof context is created.
+        ///
+        ///   1. **Proof in instruction data, no context state:**
+        ///      - No accounts are required.
+        ///
+        ///   2. **Proof in instruction data, with context state:**
+        ///      - `[writable]` The proof context account to create.
+        ///      - `[]` The proof context account owner.
+        ///
+        ///   3. **Proof in account, no context state:**
+        ///      - `[]` Account to read the proof from.
+        ///
+        ///   4. **Proof in account, with context state:**
+        ///      - `[]` Account to read the proof from.
+        ///      - `[writable]` The proof context account to create.
+        ///      - `[]` The proof context account owner.
+        pub struct $name<'a, 'b> {
+            /// Optional context state info.
+            pub context_state_info: Option<$crate::ContextStateInfo<'a>>,
+            /// Proof.
+            pub proof: $crate::Proof<'b, $proof_len>,
+        }
+
+        impl $name<'_, '_> {
+            #[inline(always)]
+            pub fn invoke(&self) -> ::solana_program_error::ProgramResult {
+                match self.proof {
+                    $crate::Proof::Account {
+                        account: proof_account,
+                        offset,
+                    } => {
+                        // Instruction data layout:
+                        // - [0]: instruction discriminator (1 byte, u8)
+                        // - [1..5]: offset (4 bytes, u32)
+                        let mut instruction_data = [$crate::UNINIT_BYTE; 1 + 4];
+
+                        instruction_data[0].write($discriminator);
+                        $crate::write_bytes(&mut instruction_data[1..], &offset.to_le_bytes());
+
+                        let instruction_data =
+                            unsafe { ::core::slice::from_raw_parts(instruction_data.as_ptr() as _, 1 + 4) };
+
+                        if let Some(ref context_state_info) = self.context_state_info {
+                            let instruction_accounts: [::solana_instruction_view::InstructionAccount; 3] = [
+                                ::solana_instruction_view::InstructionAccount::readonly(proof_account.address()),
+                                ::solana_instruction_view::InstructionAccount::writable(
+                                    context_state_info.context_state_account.address(),
+                                ),
+                                ::solana_instruction_view::InstructionAccount::readonly(
+                                    context_state_info.context_state_authority.address(),
+                                ),
+                            ];
+
+                            $crate::build_and_invoke_instruction(
+                                &instruction_accounts,
+                                instruction_data,
+                                &[
+                                    proof_account,
+                                    context_state_info.context_state_account,
+                                    context_state_info.context_state_authority,
+                                ],
+                            )
+                        } else {
+                            let instruction_accounts: [::solana_instruction_view::InstructionAccount; 1] =
+                                [::solana_instruction_view::InstructionAccount::readonly(proof_account.address())];
+
+                            $crate::build_and_invoke_instruction(
+                                &instruction_accounts,
+                                instruction_data,
+                                &[proof_account],
+                            )
+                        }
+                    }
+                    $crate::Proof::Data(proof_data) => {
+                        // Instruction data layout:
+                        // - [0]: instruction discriminator (1 byte, u8)
+                        // - [1..=$proof_len]: proof
+                        let mut instruction_data = [$crate::UNINIT_BYTE; 1 + $proof_len];
+
+                        instruction_data[0].write($discriminator);
+                        $crate::write_bytes(&mut instruction_data[1..], proof_data);
+
+                        let instruction_data = unsafe {
+                            ::core::slice::from_raw_parts(instruction_data.as_ptr() as _, 1 + $proof_len)
+                        };
+
+                        if let Some(ref context_state_info) = self.context_state_info {
+                            let instruction_accounts: [::solana_instruction_view::InstructionAccount; 2] = [
+                                ::solana_instruction_view::InstructionAccount::writable(
+                                    context_state_info.context_state_account.address(),
+                                ),
+                                ::solana_instruction_view::InstructionAccount::readonly(
+                                    context_state_info.context_state_authority.address(),
+                                ),
+                            ];
+
+                            $crate::build_and_invoke_instruction(
+                                &instruction_accounts,
+                                instruction_data,
+                                &[
+                                    context_state_info.context_state_account,
+                                    context_state_info.context_state_authority,
+                                ],
+                            )
+                        } else {
+                            $crate::build_and_invoke_instruction(&[], instruction_data, &[])
+                        }
+                    }
+                }
+            }
+        }
+    };
+}
+
+use create_instruction_struct;
+
+#[inline(always)]
+fn build_and_invoke_instruction<const ACCOUNTS: usize>(
+    accounts: &[InstructionAccount],
+    data: &[u8],
+    account_views: &[&AccountView; ACCOUNTS],
+) -> ProgramResult {
+    let instruction = InstructionView {
+        program_id: &crate::ID,
+        accounts,
+        data,
+    };
+    invoke(&instruction, account_views)
+}


### PR DESCRIPTION
Added all instructions for the ZK ElGamal Proof program.
The instructions were taken from [here](https://github.com/solana-program/zk-elgamal-proof/blob/main/zk-sdk/src/zk_elgamal_proof_program/instruction.rs).
All instructions except `CloseContextState` have the same pattern, and are implemented with a macro. For every such instruction, a proof can be provided either in the instruction data or in an account. Every type of proof has a constant size. The constants for proof lengths are the sizes of `<ProofType>Data` structs from [here](https://github.com/solana-program/zk-elgamal-proof/tree/main/zk-sdk/src/zk_elgamal_proof_program/proof_data).
Also, an optional `ContextStateInfo` can be provided to store a context.
The instruction `CloseContextState` is implemented separately.