### PR TITLE
token-2022: Fix instruction accounts reference

### DIFF
--- a/programs/token-2022/src/instructions/extensions/group_member_pointer/update.rs
+++ b/programs/token-2022/src/instructions/extensions/group_member_pointer/update.rs
@@ -95,18 +95,21 @@ impl<'a, 'b, 'c> Update<'a, 'b, 'c> {
 
         // Instruction accounts.
 
-        let mut accounts =
+        let mut instruction_accounts =
             [const { MaybeUninit::<InstructionAccount>::uninit() }; 2 + MAX_MULTISIG_SIGNERS];
 
-        accounts[0].write(InstructionAccount::writable(self.mint.address()));
+        instruction_accounts[0].write(InstructionAccount::writable(self.mint.address()));
 
-        accounts[1].write(InstructionAccount::new(
+        instruction_accounts[1].write(InstructionAccount::new(
             self.authority.address(),
             false,
             self.multisig_signers.is_empty(),
         ));
 
-        for (account, signer) in accounts[2..].iter_mut().zip(self.multisig_signers.iter()) {
+        for (account, signer) in instruction_accounts[2..]
+            .iter_mut()
+            .zip(self.multisig_signers.iter())
+        {
             account.write(InstructionAccount::readonly_signer(signer.address()));
         }
 
@@ -145,7 +148,7 @@ impl<'a, 'b, 'c> Update<'a, 'b, 'c> {
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
                 accounts: unsafe {
-                    slice::from_raw_parts(accounts.as_ptr() as _, expected_accounts)
+                    slice::from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
                 },
                 // SAFETY: instruction data is initialized.
                 data: unsafe {

--- a/programs/token-2022/src/instructions/extensions/scaled_ui_amount/update_multiplier.rs
+++ b/programs/token-2022/src/instructions/extensions/scaled_ui_amount/update_multiplier.rs
@@ -115,18 +115,21 @@ impl<'a, 'b, 'c> UpdateMultiplier<'a, 'b, 'c> {
 
         // Instruction accounts.
 
-        let mut accounts =
+        let mut instruction_accounts =
             [const { MaybeUninit::<InstructionAccount>::uninit() }; 2 + MAX_MULTISIG_SIGNERS];
 
-        accounts[0].write(InstructionAccount::writable(self.mint.address()));
+        instruction_accounts[0].write(InstructionAccount::writable(self.mint.address()));
 
-        accounts[1].write(InstructionAccount::new(
+        instruction_accounts[1].write(InstructionAccount::new(
             self.authority.address(),
             false,
             self.multisig_signers.is_empty(),
         ));
 
-        for (account, signer) in accounts[2..].iter_mut().zip(self.multisig_signers.iter()) {
+        for (account, signer) in instruction_accounts[2..]
+            .iter_mut()
+            .zip(self.multisig_signers.iter())
+        {
             account.write(InstructionAccount::readonly_signer(signer.address()));
         }
 
@@ -161,7 +164,9 @@ impl<'a, 'b, 'c> UpdateMultiplier<'a, 'b, 'c> {
             &InstructionView {
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
-                accounts: unsafe { from_raw_parts(accounts.as_ptr() as _, expected_accounts) },
+                accounts: unsafe {
+                    from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
+                },
                 // SAFETY: instruction data is initialized.
                 data: unsafe {
                     from_raw_parts(instruction_data.as_ptr() as _, instruction_data.len())


### PR DESCRIPTION
### Problem

Currently both `Update` in group member pointer and `UpdateMultiplier` in scaled ui amount are mistakenly passing an array of `AccountView` as instruction accounts because of a variable name clash.

### Solution

Use a different variable name to represent instruction accounts, as it happens in all other instructions.
