### PR TITLE
More `&mut` accounts updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ entrypoint!(process_instruction);
 
 pub fn process_instruction(
   program_id: &Address,
-  accounts: &[AccountView],
+  accounts: &mut [AccountView],
   instruction_data: &[u8],
 ) -> ProgramResult {
   log("Hello from my pinocchio program!");
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
 
 pub fn process_instruction(
   program_id: &Address,
-  accounts: &[AccountView],
+  accounts: &mut [AccountView],
   instruction_data: &[u8],
 ) -> ProgramResult {
   log("Standard path");
@@ -194,7 +194,7 @@ no_allocator!();
 
 pub fn process_instruction(
   program_id: &Address,
-  accounts: &[AccountView],
+  accounts: &mut [AccountView],
   instruction_data: &[u8],
 ) -> ProgramResult {
   Ok(())
@@ -268,7 +268,7 @@ mod entrypoint {
 
   pub fn process_instruction(
     program_id: &Address,
-    accounts: &[AccountView],
+    accounts: &mut [AccountView],
     instruction_data: &[u8],
   ) -> ProgramResult {
     Ok(())

--- a/sdk/src/entrypoint/mod.rs
+++ b/sdk/src/entrypoint/mod.rs
@@ -205,7 +205,7 @@ pub unsafe fn process_entrypoint<const MAX_ACCOUNTS: usize>(
     // they are initialized so we cast the pointer to a slice of `[AccountView]`.
     match process_instruction(
         program_id,
-        unsafe { from_raw_parts_mut(accounts.as_ptr() as _, count) },
+        unsafe { from_raw_parts_mut(accounts.as_mut_ptr() as _, count) },
         instruction_data,
     ) {
         Ok(()) => SUCCESS,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! pub fn process_instruction(
 //!   program_id: &Address,
-//!   accounts: &[AccountView],
+//!   accounts: &mut [AccountView],
 //!   instruction_data: &[u8],
 //! ) -> ProgramResult {
 //!   log!("Hello from my pinocchio program!");
@@ -113,7 +113,7 @@
 //!
 //! pub fn process_instruction(
 //!   program_id: &Address,
-//!   accounts: &[AccountView],
+//!   accounts: &mut [AccountView],
 //!   instruction_data: &[u8],
 //! ) -> ProgramResult {
 //!   log("Standard path");
@@ -205,7 +205,7 @@
 //!
 //! pub fn process_instruction(
 //!   program_id: &Address,
-//!   accounts: &[AccountView],
+//!   accounts: &mut [AccountView],
 //!   instruction_data: &[u8],
 //! ) -> ProgramResult {
 //!   Ok(())
@@ -293,7 +293,7 @@
 //!
 //!   pub fn process_instruction(
 //!     program_id: &Address,
-//!     accounts: &[AccountView],
+//!     accounts: &mut [AccountView],
 //!     instruction_data: &[u8],
 //!   ) -> ProgramResult {
 //!     Ok(())


### PR DESCRIPTION
### Problem

PR #363 bumped the account-view dependency, which requires using `&mut` references for the accounts slice. There are many places in the documentation that have not been updated. Additionally, the `&mut` slice is being created from the `*const` pointer instead of `*mut` one.

### Solution

Update the documentation and code to use `&mut` references.