### PR TITLE
programs: Use `AsRef<AccountView>` for signers

### DIFF
--- a/programs/memo/src/instructions/mod.rs
+++ b/programs/memo/src/instructions/mod.rs
@@ -12,14 +12,14 @@ use {
 ///
 /// ### Accounts:
 ///   0. `..+N` `[SIGNER]` N signing accounts
-pub struct Memo<'a, 'b, A: AsRef<AccountView>> {
+pub struct Memo<'a, 'b, S: AsRef<AccountView>> {
     /// Signing accounts
-    pub signers: &'a [A],
+    pub signers: &'a [S],
     /// Memo
     pub memo: &'b str,
 }
 
-impl<A: AsRef<AccountView>> Memo<'_, '_, A> {
+impl<S: AsRef<AccountView>> Memo<'_, '_, S> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_signed(&[])

--- a/programs/token-2022/src/instructions/extensions/cpi_guard/disable.rs
+++ b/programs/token-2022/src/instructions/extensions/cpi_guard/disable.rs
@@ -24,7 +24,7 @@ use {
 ///   0. `[writable]` The account to update.
 ///   1. `[]`  The account's multisignature owner.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct Disable<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct Disable<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The account to update.
     pub account: &'a AccountView,
 
@@ -32,13 +32,13 @@ pub struct Disable<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// The signer accounts if the authority is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The token program.
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> Disable<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Disable<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 1;
 
     /// Creates a new `Disable` instruction with a single owner/delegate
@@ -59,7 +59,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> Disable<'a, 'b, 'c, A> {
         token_program: &'b Address,
         account: &'a AccountView,
         authority: &'a AccountView,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token-2022/src/instructions/extensions/cpi_guard/enable.rs
+++ b/programs/token-2022/src/instructions/extensions/cpi_guard/enable.rs
@@ -28,7 +28,7 @@ use {
 ///   0. `[writable]` The account to update.
 ///   1. `[]` The account's multisignature owner.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct Enable<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct Enable<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The account to update.
     pub account: &'a AccountView,
 
@@ -36,13 +36,13 @@ pub struct Enable<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// The signer accounts if the authority is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The token program.
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> Enable<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Enable<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 0;
 
     /// Creates a new `Enable` instruction with a single owner/delegate
@@ -63,7 +63,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> Enable<'a, 'b, 'c, A> {
         token_program: &'b Address,
         account: &'a AccountView,
         authority: &'a AccountView,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token-2022/src/instructions/extensions/default_account_state/update.rs
+++ b/programs/token-2022/src/instructions/extensions/default_account_state/update.rs
@@ -26,7 +26,7 @@ use {
 ///   0. `[writable]` The mint.
 ///   1. `[]` The mint's multisignature freeze authority.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct Update<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The mint.
     pub mint: &'a AccountView,
 
@@ -34,7 +34,7 @@ pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub freeze_authority: &'a AccountView,
 
     /// The signer accounts if the authority is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The new account state in which new token accounts should be
     /// initialized.
@@ -44,7 +44,7 @@ pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> Update<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 1;
 
     /// Creates a new `Update` instruction with a single owner/delegate
@@ -67,7 +67,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> Update<'a, 'b, 'c, A> {
         mint: &'a AccountView,
         freeze_authority: &'a AccountView,
         state: AccountState,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token-2022/src/instructions/extensions/group_member_pointer/update.rs
+++ b/programs/token-2022/src/instructions/extensions/group_member_pointer/update.rs
@@ -29,7 +29,7 @@ use {
 ///   0. `[writable]` The mint.
 ///   1. `[]`         The group member pointer authority.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct Update<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The mint.
     pub mint: &'a AccountView,
 
@@ -40,13 +40,13 @@ pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub member_address: Option<&'b Address>,
 
     /// The signer accounts if `authority` is a multisig
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// Token Program
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> Update<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 1;
 
     /// Creates a new `Update` instruction with a single owner/delegate
@@ -69,7 +69,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> Update<'a, 'b, 'c, A> {
         mint: &'a AccountView,
         authority: &'a AccountView,
         member_address: Option<&'b Address>,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token-2022/src/instructions/extensions/group_pointer/update.rs
+++ b/programs/token-2022/src/instructions/extensions/group_pointer/update.rs
@@ -29,7 +29,7 @@ use {
 ///   0. `[writable]` The mint.
 ///   1. `[]` The mint's group pointer authority.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct Update<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The mint.
     pub mint: &'a AccountView,
 
@@ -37,7 +37,7 @@ pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// The signer accounts if `authority` is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The new account address that holds the group configurations.
     pub group_address: Option<&'b Address>,
@@ -46,7 +46,7 @@ pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> Update<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 1;
 
     /// Creates a new `Update` instruction with a single owner/delegate
@@ -69,7 +69,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> Update<'a, 'b, 'c, A> {
         mint: &'a AccountView,
         authority: &'a AccountView,
         group_address: Option<&'b Address>,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token-2022/src/instructions/extensions/interest_bearing_mint/update.rs
+++ b/programs/token-2022/src/instructions/extensions/interest_bearing_mint/update.rs
@@ -29,7 +29,7 @@ use {
 ///   0. `[writable]` The mint.
 ///   1. `[]` The mint's multisignature rate authority.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct Update<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The mint.
     pub mint: &'a AccountView,
 
@@ -37,7 +37,7 @@ pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// The signer accounts if `authority` is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The new interest rate.
     pub rate: i16,
@@ -46,7 +46,7 @@ pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> Update<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 1;
 
     /// Creates a new `Update` instruction with a single owner/delegate
@@ -69,7 +69,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> Update<'a, 'b, 'c, A> {
         mint: &'a AccountView,
         authority: &'a AccountView,
         rate: i16,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token-2022/src/instructions/extensions/memo_transfer/disable.rs
+++ b/programs/token-2022/src/instructions/extensions/memo_transfer/disable.rs
@@ -24,7 +24,7 @@ use {
 ///   0. `[writable]` The account to update.
 ///   1. `[]`  The account's multisignature owner.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct Disable<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct Disable<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The account to update.
     pub account: &'a AccountView,
 
@@ -32,13 +32,13 @@ pub struct Disable<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// Signer accounts if the authority is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The token program.
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> Disable<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Disable<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 1;
 
     /// Creates a new `Disable` instruction with a single owner/delegate
@@ -59,7 +59,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> Disable<'a, 'b, 'c, A> {
         token_program: &'b Address,
         account: &'a AccountView,
         authority: &'a AccountView,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token-2022/src/instructions/extensions/memo_transfer/enable.rs
+++ b/programs/token-2022/src/instructions/extensions/memo_transfer/enable.rs
@@ -22,7 +22,7 @@ use {
 ///   0. `[writable]` The account to update.
 ///   1. `[]` The account's multisignature owner.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct Enable<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct Enable<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The account to update.
     pub account: &'a AccountView,
 
@@ -30,13 +30,13 @@ pub struct Enable<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// Signer accounts if the authority is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The token program.
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> Enable<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Enable<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 0;
 
     /// Creates a new `Enable` instruction with a single owner/delegate
@@ -57,7 +57,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> Enable<'a, 'b, 'c, A> {
         token_program: &'b Address,
         account: &'a AccountView,
         authority: &'a AccountView,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token-2022/src/instructions/extensions/metadata_pointer/update.rs
+++ b/programs/token-2022/src/instructions/extensions/metadata_pointer/update.rs
@@ -29,7 +29,7 @@ use {
 ///   0. `[writable]` The mint.
 ///   1. `[]` The mint's metadata pointer authority.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct Update<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The mint.
     pub mint: &'a AccountView,
 
@@ -37,7 +37,7 @@ pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// The signer accounts when `authority` is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The new account address that holds the metadata.
     pub metadata_address: Option<&'b Address>,
@@ -46,7 +46,7 @@ pub struct Update<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> Update<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 1;
 
     /// Creates a new `Update` instruction with a single owner/delegate
@@ -69,7 +69,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> Update<'a, 'b, 'c, A> {
         mint: &'a AccountView,
         authority: &'a AccountView,
         metadata_address: Option<&'b Address>,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token-2022/src/instructions/extensions/pausable/pause.rs
+++ b/programs/token-2022/src/instructions/extensions/pausable/pause.rs
@@ -21,7 +21,7 @@ use {
 ///   0. `[writable]` The mint to update.
 ///   1. `[]` The mint's multisignature pause authority.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct Pause<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct Pause<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The mint to update.
     pub mint: &'a AccountView,
 
@@ -29,13 +29,13 @@ pub struct Pause<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// The signer accounts if the authority is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The token program.
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> Pause<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Pause<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 1;
 
     /// Creates a new `Pause` instruction with a single owner/delegate
@@ -56,7 +56,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> Pause<'a, 'b, 'c, A> {
         token_program: &'b Address,
         mint: &'a AccountView,
         authority: &'a AccountView,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token-2022/src/instructions/extensions/pausable/resume.rs
+++ b/programs/token-2022/src/instructions/extensions/pausable/resume.rs
@@ -21,7 +21,7 @@ use {
 ///   0. `[writable]` The mint to update.
 ///   1. `[]` The mint's multisignature pause authority.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct Resume<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct Resume<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The mint to update.
     pub mint: &'a AccountView,
 
@@ -29,13 +29,13 @@ pub struct Resume<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// The signer accounts if the authority is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The token program.
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> Resume<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Resume<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 2;
 
     /// Creates a new `Resume` instruction with a single owner/delegate
@@ -56,7 +56,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> Resume<'a, 'b, 'c, A> {
         token_program: &'b Address,
         mint: &'a AccountView,
         authority: &'a AccountView,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token-2022/src/instructions/extensions/permissioned_burn/burn.rs
+++ b/programs/token-2022/src/instructions/extensions/permissioned_burn/burn.rs
@@ -34,7 +34,7 @@ use {
 ///      any.
 ///   3. `[]` The source account's multisignature owner/delegate.
 ///   4. `..4+M` `[signer]` M signer accounts for the multisig.
-pub struct Burn<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct Burn<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The source account to burn from.
     pub account: &'a AccountView,
 
@@ -48,7 +48,7 @@ pub struct Burn<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// Signer accounts for multisignature authority, if applicable.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The amount of tokens to burn.
     pub amount: u64,
@@ -57,7 +57,7 @@ pub struct Burn<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> Burn<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Burn<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 1;
 
     /// Creates a new `Burn` instruction with a single owner/delegate
@@ -92,7 +92,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> Burn<'a, 'b, 'c, A> {
         permissioned_burn_authority: &'a AccountView,
         authority: &'a AccountView,
         amount: u64,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token-2022/src/instructions/extensions/permissioned_burn/burn_checked.rs
+++ b/programs/token-2022/src/instructions/extensions/permissioned_burn/burn_checked.rs
@@ -35,7 +35,7 @@ use {
 ///      any.
 ///   3. `[]` The source account's multisignature owner/delegate.
 ///   4. `..4+M` `[signer]` M signer accounts for the multisig.
-pub struct BurnChecked<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct BurnChecked<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The source account to burn from.
     pub account: &'a AccountView,
 
@@ -49,7 +49,7 @@ pub struct BurnChecked<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// Signer accounts for multisignature authority, if applicable.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The amount of tokens to burn.
     pub amount: u64,
@@ -61,7 +61,7 @@ pub struct BurnChecked<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> BurnChecked<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> BurnChecked<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 2;
 
     /// Creates a new `BurnChecked` instruction with a single owner/delegate
@@ -100,7 +100,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> BurnChecked<'a, 'b, 'c, A> {
         authority: &'a AccountView,
         amount: u64,
         decimals: u8,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token-2022/src/instructions/extensions/scaled_ui_amount/update_multiplier.rs
+++ b/programs/token-2022/src/instructions/extensions/scaled_ui_amount/update_multiplier.rs
@@ -36,7 +36,7 @@ use {
 ///   0. `[writable]` The mint.
 ///   1. `[]` The mint's multisignature multiplier authority.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct UpdateMultiplier<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct UpdateMultiplier<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The mint.
     pub mint: &'a AccountView,
 
@@ -44,7 +44,7 @@ pub struct UpdateMultiplier<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// Signer accounts if the authority is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The new multiplier.
     pub multiplier: f64,
@@ -56,7 +56,7 @@ pub struct UpdateMultiplier<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> UpdateMultiplier<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> UpdateMultiplier<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 1;
 
     /// Creates a new `UpdateMultiplier` instruction with a single
@@ -88,7 +88,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> UpdateMultiplier<'a, 'b, 'c, A> {
         authority: &'a AccountView,
         multiplier: f64,
         effective_timestamp: i64,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token-2022/src/instructions/extensions/transfer_fee/harvest_withheld_tokens_to_mint.rs
+++ b/programs/token-2022/src/instructions/extensions/transfer_fee/harvest_withheld_tokens_to_mint.rs
@@ -21,18 +21,18 @@ use {
 ///
 ///   0. `[writable]` The mint.
 ///   1. `..1+N` `[writable]` The source accounts to harvest from.
-pub struct HarvestWithheldTokensToMint<'a, 'b, 'c> {
+pub struct HarvestWithheldTokensToMint<'a, 'b, 'c, Source: AsRef<AccountView>> {
     /// The token mint.
     pub mint: &'a AccountView,
 
     /// The source accounts to harvest from.
-    pub sources: &'c [&'a AccountView],
+    pub sources: &'c [Source],
 
     /// The token program.
     pub token_program: &'b Address,
 }
 
-impl HarvestWithheldTokensToMint<'_, '_, '_> {
+impl<Source: AsRef<AccountView>> HarvestWithheldTokensToMint<'_, '_, '_, Source> {
     pub const DISCRIMINATOR: u8 = 4;
 
     #[inline(always)]
@@ -54,7 +54,7 @@ impl HarvestWithheldTokensToMint<'_, '_, '_> {
             .iter_mut()
             .zip(self.sources.iter())
         {
-            instruction_account.write(InstructionAccount::writable(source.address()));
+            instruction_account.write(InstructionAccount::writable(source.as_ref().address()));
         }
 
         // Accounts.
@@ -65,7 +65,7 @@ impl HarvestWithheldTokensToMint<'_, '_, '_> {
         accounts[0].write(self.mint);
 
         for (account, source) in accounts[1..].iter_mut().zip(self.sources.iter()) {
-            account.write(*source);
+            account.write(source.as_ref());
         }
 
         invoke_with_bounds::<MAX_STATIC_CPI_ACCOUNTS, &AccountView>(

--- a/programs/token-2022/src/instructions/extensions/transfer_fee/set_transfer_fee.rs
+++ b/programs/token-2022/src/instructions/extensions/transfer_fee/set_transfer_fee.rs
@@ -26,7 +26,7 @@ use {
 ///   0. `[writable]` The mint.
 ///   1. `[]` The mint's multisignature fee account owner.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct SetTransferFee<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct SetTransferFee<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The token mint.
     pub mint: &'a AccountView,
 
@@ -34,7 +34,7 @@ pub struct SetTransferFee<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// Multisignature owner/delegate.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// Amount of transfer collected as fees, expressed as basis points of
     /// the transfer amount
@@ -47,7 +47,7 @@ pub struct SetTransferFee<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> SetTransferFee<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> SetTransferFee<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 5;
 
     /// Creates a new `SetTransferFee` instruction with a single owner/delegate
@@ -79,7 +79,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> SetTransferFee<'a, 'b, 'c, A> {
         authority: &'a AccountView,
         transfer_fee_basis_points: u16,
         maximum_fee: u64,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token-2022/src/instructions/extensions/transfer_fee/transfer_checked_with_fee.rs
+++ b/programs/token-2022/src/instructions/extensions/transfer_fee/transfer_checked_with_fee.rs
@@ -35,7 +35,7 @@ use {
 ///   2. `[writable]` The destination account.
 ///   3. `[]` The source account's multisignature.
 ///   4. `..+N` `[]` The `N` signer accounts, where `N` is `1 <= N <= 11`.
-pub struct TransferCheckedWithFee<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct TransferCheckedWithFee<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The source account.
     pub source: &'a AccountView,
 
@@ -49,7 +49,7 @@ pub struct TransferCheckedWithFee<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// Multisignature owner/delegate.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The amount of tokens to transfer.
     pub amount: u64,
@@ -66,7 +66,9 @@ pub struct TransferCheckedWithFee<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> TransferCheckedWithFee<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>>
+    TransferCheckedWithFee<'a, 'b, 'c, MultisigSigner>
+{
     /// Instruction discriminator.
     pub const DISCRIMINATOR: u8 = 1;
 
@@ -110,7 +112,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> TransferCheckedWithFee<'a, 'b, 'c, A> {
         amount: u64,
         decimals: u8,
         fee: u64,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             source,

--- a/programs/token-2022/src/instructions/extensions/transfer_fee/withdraw_withheld_tokens_from_accounts.rs
+++ b/programs/token-2022/src/instructions/extensions/transfer_fee/withdraw_withheld_tokens_from_accounts.rs
@@ -28,7 +28,13 @@ use {
 ///   2. `[]` The mint's multisig `withdraw_withheld_authority`.
 ///   3. `..3+M` `[signer]` M signer accounts.
 ///   4. `3+M+1..3+M+N` `[writable]` The source accounts to withdraw from.
-pub struct WithdrawWithheldTokensFromAccounts<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct WithdrawWithheldTokensFromAccounts<
+    'a,
+    'b,
+    'c,
+    MultisigSigner: AsRef<AccountView>,
+    Source: AsRef<AccountView>,
+> {
     /// The token mint.
     pub mint: &'a AccountView,
 
@@ -39,16 +45,18 @@ pub struct WithdrawWithheldTokensFromAccounts<'a, 'b, 'c, A: AsRef<AccountView>>
     pub authority: &'a AccountView,
 
     /// Multisignature signer accounts.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// Source accounts to withdraw from.
-    pub sources: &'c [A],
+    pub sources: &'c [Source],
 
     /// Token program.
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> WithdrawWithheldTokensFromAccounts<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>, Source: AsRef<AccountView>>
+    WithdrawWithheldTokensFromAccounts<'a, 'b, 'c, MultisigSigner, Source>
+{
     pub const DISCRIMINATOR: u8 = 3;
 
     /// Creates a new `WithdrawWithheldTokensFromAccounts` instruction
@@ -59,7 +67,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> WithdrawWithheldTokensFromAccounts<'a, '
         mint: &'a AccountView,
         destination: &'a AccountView,
         authority: &'a AccountView,
-        sources: &'c [A],
+        sources: &'c [Source],
     ) -> Self {
         Self::with_multisig_signers(token_program, mint, destination, authority, sources, &[])
     }
@@ -72,8 +80,8 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> WithdrawWithheldTokensFromAccounts<'a, '
         mint: &'a AccountView,
         destination: &'a AccountView,
         authority: &'a AccountView,
-        sources: &'c [A],
-        multisig_signers: &'c [A],
+        sources: &'c [Source],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token-2022/src/instructions/extensions/transfer_fee/withdraw_withheld_tokens_from_mint.rs
+++ b/programs/token-2022/src/instructions/extensions/transfer_fee/withdraw_withheld_tokens_from_mint.rs
@@ -27,7 +27,7 @@ use {
 ///   1. `[writable]` The destination account.
 ///   2. `[]` The mint's multisig `withdraw_withheld_authority`.
 ///   3. `..3+M` `[signer]` M signer accounts.
-pub struct WithdrawWithheldTokensFromMint<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct WithdrawWithheldTokensFromMint<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The token mint.
     pub mint: &'a AccountView,
 
@@ -38,13 +38,15 @@ pub struct WithdrawWithheldTokensFromMint<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// Multisignature owner/delegate.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// Token program.
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> WithdrawWithheldTokensFromMint<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>>
+    WithdrawWithheldTokensFromMint<'a, 'b, 'c, MultisigSigner>
+{
     pub const DISCRIMINATOR: u8 = 2;
 
     /// Creates a new `WithdrawWithheldTokensFromMint` instruction
@@ -67,7 +69,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> WithdrawWithheldTokensFromMint<'a, 'b, '
         mint: &'a AccountView,
         destination: &'a AccountView,
         authority: &'a AccountView,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token-2022/src/instructions/extensions/transfer_hook/update.rs
+++ b/programs/token-2022/src/instructions/extensions/transfer_hook/update.rs
@@ -29,7 +29,7 @@ use {
 ///   0. `[writable]` The mint.
 ///   1. `[]` The mint's transfer hook authority.
 ///   2. `..2+M` `[signer]` M signer accounts.
-pub struct UpdateTransferHook<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct UpdateTransferHook<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The mint.
     pub mint: &'a AccountView,
 
@@ -37,7 +37,7 @@ pub struct UpdateTransferHook<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// The signer accounts when `authority` is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// Program that authorizes the transfer.
     pub transfer_hook_program: Option<&'b Address>,
@@ -46,7 +46,9 @@ pub struct UpdateTransferHook<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> UpdateTransferHook<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>>
+    UpdateTransferHook<'a, 'b, 'c, MultisigSigner>
+{
     pub const DISCRIMINATOR: u8 = 1;
 
     /// Creates a new `UpdateTransferHook` instruction with a single
@@ -69,7 +71,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> UpdateTransferHook<'a, 'b, 'c, A> {
         mint: &'a AccountView,
         authority: &'a AccountView,
         transfer_hook_program: Option<&'b Address>,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token-2022/src/instructions/initialize_multisig.rs
+++ b/programs/token-2022/src/instructions/initialize_multisig.rs
@@ -15,7 +15,7 @@ pub const MAX_MULTISIG_SIGNERS: usize = 11;
 ///   0. `[writable]` The multisig account to initialize.
 ///   1. `[]` Rent sysvar
 ///   2. `..+N` `[]` The `N` signer accounts, where `N` is `1 <= N <= 11`.
-pub struct InitializeMultisig<'a, 'b, 'c, A: AsRef<AccountView>>
+pub struct InitializeMultisig<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>>
 where
     'a: 'b,
 {
@@ -24,7 +24,7 @@ where
     /// Rent sysvar Account.
     pub rent_sysvar: &'a AccountView,
     /// Signer Accounts
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
     /// The number of signers (M) required to validate this multisignature
     /// account.
     pub m: u8,
@@ -32,7 +32,7 @@ where
     pub token_program: &'c Address,
 }
 
-impl<A: AsRef<AccountView>> InitializeMultisig<'_, '_, '_, A> {
+impl<MultisigSigner: AsRef<AccountView>> InitializeMultisig<'_, '_, '_, MultisigSigner> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         let &Self {

--- a/programs/token-2022/src/instructions/initialize_multisig_2.rs
+++ b/programs/token-2022/src/instructions/initialize_multisig_2.rs
@@ -12,14 +12,14 @@ use {
 /// ### Accounts:
 ///   0. `[writable]` The multisig account to initialize.
 ///   1. `..+N` `[]` The `N` signer accounts, where `N` is `1 <= N <= 11`.
-pub struct InitializeMultisig2<'a, 'b, 'c, A: AsRef<AccountView>>
+pub struct InitializeMultisig2<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>>
 where
     'a: 'b,
 {
     /// Multisig Account.
     pub multisig: &'a AccountView,
     /// Signer Accounts
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
     /// The number of signers (M) required to validate this multisignature
     /// account.
     pub m: u8,
@@ -27,7 +27,7 @@ where
     pub token_program: &'c Address,
 }
 
-impl<A: AsRef<AccountView>> InitializeMultisig2<'_, '_, '_, A> {
+impl<MultisigSigner: AsRef<AccountView>> InitializeMultisig2<'_, '_, '_, MultisigSigner> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         let &Self {

--- a/programs/token-2022/src/instructions/reallocate.rs
+++ b/programs/token-2022/src/instructions/reallocate.rs
@@ -31,7 +31,7 @@ use {
 ///   2. `[]` System program for reallocation funding
 ///   3. `[]` The account's multisignature owner/delegate.
 ///   4. ..`4+M` `[signer]` M signer accounts.
-pub struct Reallocate<'a, 'b, 'c, 'd, A: AsRef<AccountView>> {
+pub struct Reallocate<'a, 'b, 'c, 'd, MultisigSigner: AsRef<AccountView>> {
     /// The account to reallocate.
     pub account: &'a AccountView,
 
@@ -45,7 +45,7 @@ pub struct Reallocate<'a, 'b, 'c, 'd, A: AsRef<AccountView>> {
     pub owner: &'a AccountView,
 
     /// The signer accounts for multisignature owner, if applicable.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// New extension types to include in the reallocated account
     pub extensions: &'d [ExtensionDiscriminator],
@@ -54,7 +54,9 @@ pub struct Reallocate<'a, 'b, 'c, 'd, A: AsRef<AccountView>> {
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, 'd, A: AsRef<AccountView>> Reallocate<'a, 'b, 'c, 'd, A> {
+impl<'a, 'b, 'c, 'd, MultisigSigner: AsRef<AccountView>>
+    Reallocate<'a, 'b, 'c, 'd, MultisigSigner>
+{
     pub const DISCRIMINATOR: u8 = 29;
 
     /// Creates a new `Reallocate` instruction with a single owner/delegate
@@ -89,7 +91,7 @@ impl<'a, 'b, 'c, 'd, A: AsRef<AccountView>> Reallocate<'a, 'b, 'c, 'd, A> {
         system_program: &'a AccountView,
         owner: &'a AccountView,
         extensions: &'d [ExtensionDiscriminator],
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token-2022/src/instructions/unwrap_lamports.rs
+++ b/programs/token-2022/src/instructions/unwrap_lamports.rs
@@ -26,7 +26,7 @@ use {
 ///   1. `[writable]` The destination account.
 ///   2. `[]` The source account's multisignature owner/delegate.
 ///   3. `..+M` `[signer]` M signer accounts.
-pub struct UnwrapLamports<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct UnwrapLamports<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// The source account.
     pub source: &'a AccountView,
 
@@ -37,7 +37,7 @@ pub struct UnwrapLamports<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// Multisignature owner/delegate.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The amount of lamports to transfer.
     pub amount: Option<u64>,
@@ -46,7 +46,7 @@ pub struct UnwrapLamports<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> UnwrapLamports<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> UnwrapLamports<'a, 'b, 'c, MultisigSigner> {
     pub const DISCRIMINATOR: u8 = 45;
 
     /// Creates a new `UnwrapLamports` instruction with a single
@@ -71,7 +71,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> UnwrapLamports<'a, 'b, 'c, A> {
         destination: &'a AccountView,
         authority: &'a AccountView,
         amount: Option<u64>,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             source: account,

--- a/programs/token-2022/src/instructions/withdraw_excess_lamports.rs
+++ b/programs/token-2022/src/instructions/withdraw_excess_lamports.rs
@@ -18,7 +18,7 @@ use {
 /// 1. `[writable]` Destination account.
 /// 2. `[signer]` Authority.
 /// 3. ..`3+M` `[signer]` M signer accounts.
-pub struct WidthdrawExcessLamports<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct WidthdrawExcessLamports<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// Source account owned by the token program.
     pub source: &'a AccountView,
 
@@ -29,13 +29,15 @@ pub struct WidthdrawExcessLamports<'a, 'b, 'c, A: AsRef<AccountView>> {
     pub authority: &'a AccountView,
 
     /// The signer accounts if the authority is a multisig.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
 
     /// The token program.
     pub token_program: &'b Address,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> WidthdrawExcessLamports<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>>
+    WidthdrawExcessLamports<'a, 'b, 'c, MultisigSigner>
+{
     pub const DISCRIMINATOR: u8 = 38;
 
     /// Creates a new `WidthdrawExcessLamports` instruction with a single
@@ -58,7 +60,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> WidthdrawExcessLamports<'a, 'b, 'c, A> {
         source: &'a AccountView,
         destination: &'a AccountView,
         authority: &'a AccountView,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             source,

--- a/programs/token/src/instructions/approve.rs
+++ b/programs/token/src/instructions/approve.rs
@@ -22,7 +22,7 @@ use {
 ///   1. `[]` The delegate.
 ///   2. `[]` The source account's multisignature owner.
 ///   3. `..3+M` `[SIGNER]` M signer accounts
-pub struct Approve<'a, 'b, A: AsRef<AccountView>> {
+pub struct Approve<'a, 'b, MultisigSigner: AsRef<AccountView>> {
     /// Source Account.
     pub source: &'a AccountView,
     /// Delegate Account
@@ -30,12 +30,12 @@ pub struct Approve<'a, 'b, A: AsRef<AccountView>> {
     /// Source Owner Account
     pub authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
     /// Amount
     pub amount: u64,
 }
 
-impl<'a, 'b, A: AsRef<AccountView>> Approve<'a, 'b, A> {
+impl<'a, 'b, MultisigSigner: AsRef<AccountView>> Approve<'a, 'b, MultisigSigner> {
     /// Creates a new `Approve` instruction with a single owner authority.
     #[inline(always)]
     pub fn new(
@@ -55,7 +55,7 @@ impl<'a, 'b, A: AsRef<AccountView>> Approve<'a, 'b, A> {
         delegate: &'a AccountView,
         authority: &'a AccountView,
         amount: u64,
-        multisig_signers: &'b [A],
+        multisig_signers: &'b [MultisigSigner],
     ) -> Self {
         Self {
             source,

--- a/programs/token/src/instructions/approve_checked.rs
+++ b/programs/token/src/instructions/approve_checked.rs
@@ -24,7 +24,7 @@ use {
 ///   2. `[]` The delegate.
 ///   3. `[]` The source account's multisignature owner.
 ///   4. `..4+M` `[SIGNER]` M signer accounts
-pub struct ApproveChecked<'a, 'b, A: AsRef<AccountView>> {
+pub struct ApproveChecked<'a, 'b, MultisigSigner: AsRef<AccountView>> {
     /// Source Account.
     pub source: &'a AccountView,
     /// Mint Account.
@@ -34,14 +34,14 @@ pub struct ApproveChecked<'a, 'b, A: AsRef<AccountView>> {
     /// Source Owner Account.
     pub authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
     /// Amount.
     pub amount: u64,
     /// Decimals.
     pub decimals: u8,
 }
 
-impl<'a, 'b, A: AsRef<AccountView>> ApproveChecked<'a, 'b, A> {
+impl<'a, 'b, MultisigSigner: AsRef<AccountView>> ApproveChecked<'a, 'b, MultisigSigner> {
     /// Creates a new `ApproveChecked` instruction with a single owner
     /// authority.
     #[inline(always)]
@@ -66,7 +66,7 @@ impl<'a, 'b, A: AsRef<AccountView>> ApproveChecked<'a, 'b, A> {
         authority: &'a AccountView,
         amount: u64,
         decimals: u8,
-        multisig_signers: &'b [A],
+        multisig_signers: &'b [MultisigSigner],
     ) -> Self {
         Self {
             source,

--- a/programs/token/src/instructions/burn.rs
+++ b/programs/token/src/instructions/burn.rs
@@ -22,7 +22,7 @@ use {
 ///   1. `[WRITE]` The token mint.
 ///   2. `[]` The account's multisignature owner/delegate.
 ///   3. `..3+M` `[SIGNER]` M signer accounts
-pub struct Burn<'a, 'b, A: AsRef<AccountView>> {
+pub struct Burn<'a, 'b, MultisigSigner: AsRef<AccountView>> {
     /// Source of the Burn Account
     pub account: &'a AccountView,
     /// Mint Account
@@ -30,12 +30,12 @@ pub struct Burn<'a, 'b, A: AsRef<AccountView>> {
     /// Owner of the Token Account
     pub authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
     /// Amount
     pub amount: u64,
 }
 
-impl<'a, 'b, A: AsRef<AccountView>> Burn<'a, 'b, A> {
+impl<'a, 'b, MultisigSigner: AsRef<AccountView>> Burn<'a, 'b, MultisigSigner> {
     /// Creates a new `Burn` instruction with a single
     /// owner/delegate authority.
     #[inline(always)]
@@ -56,7 +56,7 @@ impl<'a, 'b, A: AsRef<AccountView>> Burn<'a, 'b, A> {
         mint: &'a AccountView,
         authority: &'a AccountView,
         amount: u64,
-        multisig_signers: &'b [A],
+        multisig_signers: &'b [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token/src/instructions/burn_checked.rs
+++ b/programs/token/src/instructions/burn_checked.rs
@@ -22,7 +22,7 @@ use {
 ///   1. `[WRITE]` The token mint.
 ///   2. `[]` The account's multisignature owner/delegate.
 ///   3. `..3+M` `[SIGNER]` M signer accounts
-pub struct BurnChecked<'a, 'b, A: AsRef<AccountView>> {
+pub struct BurnChecked<'a, 'b, MultisigSigner: AsRef<AccountView>> {
     /// Source of the Burn Account
     pub account: &'a AccountView,
     /// Mint Account
@@ -30,14 +30,14 @@ pub struct BurnChecked<'a, 'b, A: AsRef<AccountView>> {
     /// Owner of the Token Account
     pub authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
     /// Amount
     pub amount: u64,
     /// Decimals
     pub decimals: u8,
 }
 
-impl<'a, 'b, A: AsRef<AccountView>> BurnChecked<'a, 'b, A> {
+impl<'a, 'b, MultisigSigner: AsRef<AccountView>> BurnChecked<'a, 'b, MultisigSigner> {
     /// Creates a new `BurnChecked` instruction with a single
     /// owner/delegate authority.
     #[inline(always)]
@@ -60,7 +60,7 @@ impl<'a, 'b, A: AsRef<AccountView>> BurnChecked<'a, 'b, A> {
         authority: &'a AccountView,
         amount: u64,
         decimals: u8,
-        multisig_signers: &'b [A],
+        multisig_signers: &'b [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token/src/instructions/close_account.rs
+++ b/programs/token/src/instructions/close_account.rs
@@ -22,7 +22,7 @@ use {
 ///   1. `[WRITE]` The destination account.
 ///   2. `[]` The account's multisignature owner.
 ///   3. `..3+M` `[SIGNER]` M signer accounts
-pub struct CloseAccount<'a, 'b, A: AsRef<AccountView>> {
+pub struct CloseAccount<'a, 'b, MultisigSigner: AsRef<AccountView>> {
     /// Token Account.
     pub account: &'a AccountView,
     /// Destination Account
@@ -30,10 +30,10 @@ pub struct CloseAccount<'a, 'b, A: AsRef<AccountView>> {
     /// Owner Account
     pub authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
 }
 
-impl<'a, 'b, A: AsRef<AccountView>> CloseAccount<'a, 'b, A> {
+impl<'a, 'b, MultisigSigner: AsRef<AccountView>> CloseAccount<'a, 'b, MultisigSigner> {
     /// Creates a new `CloseAccount` instruction with a single owner authority.
     #[inline(always)]
     pub fn new(
@@ -51,7 +51,7 @@ impl<'a, 'b, A: AsRef<AccountView>> CloseAccount<'a, 'b, A> {
         account: &'a AccountView,
         destination: &'a AccountView,
         authority: &'a AccountView,
-        multisig_signers: &'b [A],
+        multisig_signers: &'b [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token/src/instructions/freeze_account.rs
+++ b/programs/token/src/instructions/freeze_account.rs
@@ -22,7 +22,7 @@ use {
 ///   1. `[]` The token mint.
 ///   2. `[]` The mint's multisignature freeze authority.
 ///   3. `..3+M` `[SIGNER]` M signer accounts
-pub struct FreezeAccount<'a, 'b, A: AsRef<AccountView>> {
+pub struct FreezeAccount<'a, 'b, MultisigSigner: AsRef<AccountView>> {
     /// Token Account to freeze.
     pub account: &'a AccountView,
     /// Mint Account.
@@ -30,10 +30,10 @@ pub struct FreezeAccount<'a, 'b, A: AsRef<AccountView>> {
     /// Mint Freeze Authority Account
     pub freeze_authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
 }
 
-impl<'a, 'b, A: AsRef<AccountView>> FreezeAccount<'a, 'b, A> {
+impl<'a, 'b, MultisigSigner: AsRef<AccountView>> FreezeAccount<'a, 'b, MultisigSigner> {
     /// Creates a new `FreezeAccount` instruction with a single freeze
     /// authority.
     #[inline(always)]
@@ -52,7 +52,7 @@ impl<'a, 'b, A: AsRef<AccountView>> FreezeAccount<'a, 'b, A> {
         account: &'a AccountView,
         mint: &'a AccountView,
         freeze_authority: &'a AccountView,
-        multisig_signers: &'b [A],
+        multisig_signers: &'b [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token/src/instructions/initialize_multisig.rs
+++ b/programs/token/src/instructions/initialize_multisig.rs
@@ -14,7 +14,7 @@ pub const MAX_MULTISIG_SIGNERS: usize = 11;
 ///   0. `[writable]` The multisig account to initialize.
 ///   1. `[]` Rent sysvar
 ///   2. ..`2+N`. `[]` The N signer accounts, where N is between 1 and 11.
-pub struct InitializeMultisig<'a, 'b, A: AsRef<AccountView>>
+pub struct InitializeMultisig<'a, 'b, MultisigSigner: AsRef<AccountView>>
 where
     'a: 'b,
 {
@@ -23,13 +23,13 @@ where
     /// Rent sysvar Account.
     pub rent_sysvar: &'a AccountView,
     /// Signer Accounts
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
     /// The number of signers (M) required to validate this multisignature
     /// account.
     pub m: u8,
 }
 
-impl<A: AsRef<AccountView>> InitializeMultisig<'_, '_, A> {
+impl<MultisigSigner: AsRef<AccountView>> InitializeMultisig<'_, '_, MultisigSigner> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         let &Self {

--- a/programs/token/src/instructions/initialize_multisig_2.rs
+++ b/programs/token/src/instructions/initialize_multisig_2.rs
@@ -11,20 +11,20 @@ use {
 /// ### Accounts:
 ///   0. `[writable]` The multisig account to initialize.
 ///   1. ..`1+N`. `[]` The N signer accounts, where N is between 1 and 11.
-pub struct InitializeMultisig2<'a, 'b, A: AsRef<AccountView>>
+pub struct InitializeMultisig2<'a, 'b, MultisigSigner: AsRef<AccountView>>
 where
     'a: 'b,
 {
     /// Multisig Account.
     pub multisig: &'a AccountView,
     /// Signer Accounts
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
     /// The number of signers (M) required to validate this multisignature
     /// account.
     pub m: u8,
 }
 
-impl<A: AsRef<AccountView>> InitializeMultisig2<'_, '_, A> {
+impl<MultisigSigner: AsRef<AccountView>> InitializeMultisig2<'_, '_, MultisigSigner> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         let &Self {

--- a/programs/token/src/instructions/mint_to.rs
+++ b/programs/token/src/instructions/mint_to.rs
@@ -22,7 +22,7 @@ use {
 ///   1. `[WRITE]` The account to mint tokens to.
 ///   2. `[]` The mint's multisignature minting authority.
 ///   3. `..3+M` `[SIGNER]` M signer accounts
-pub struct MintTo<'a, 'b, A: AsRef<AccountView>> {
+pub struct MintTo<'a, 'b, MultisigSigner: AsRef<AccountView>> {
     /// Mint Account.
     pub mint: &'a AccountView,
     /// Token Account.
@@ -30,12 +30,12 @@ pub struct MintTo<'a, 'b, A: AsRef<AccountView>> {
     /// Mint Authority
     pub mint_authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
     /// Amount
     pub amount: u64,
 }
 
-impl<'a, 'b, A: AsRef<AccountView>> MintTo<'a, 'b, A> {
+impl<'a, 'b, MultisigSigner: AsRef<AccountView>> MintTo<'a, 'b, MultisigSigner> {
     /// Creates a new `MintTo` instruction with a single mint authority.
     #[inline(always)]
     pub fn new(
@@ -55,7 +55,7 @@ impl<'a, 'b, A: AsRef<AccountView>> MintTo<'a, 'b, A> {
         account: &'a AccountView,
         mint_authority: &'a AccountView,
         amount: u64,
-        multisig_signers: &'b [A],
+        multisig_signers: &'b [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token/src/instructions/mint_to_checked.rs
+++ b/programs/token/src/instructions/mint_to_checked.rs
@@ -22,7 +22,7 @@ use {
 ///   1. `[WRITE]` The account to mint tokens to.
 ///   2. `[]` The mint's multisignature minting authority.
 ///   3. `..3+M` `[SIGNER]` M signer accounts
-pub struct MintToChecked<'a, 'b, A: AsRef<AccountView>> {
+pub struct MintToChecked<'a, 'b, MultisigSigner: AsRef<AccountView>> {
     /// Mint Account.
     pub mint: &'a AccountView,
     /// Token Account.
@@ -30,14 +30,14 @@ pub struct MintToChecked<'a, 'b, A: AsRef<AccountView>> {
     /// Mint Authority
     pub mint_authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
     /// Amount
     pub amount: u64,
     /// Decimals
     pub decimals: u8,
 }
 
-impl<'a, 'b, A: AsRef<AccountView>> MintToChecked<'a, 'b, A> {
+impl<'a, 'b, MultisigSigner: AsRef<AccountView>> MintToChecked<'a, 'b, MultisigSigner> {
     /// Creates a new `MintToChecked` instruction with a single mint authority.
     #[inline(always)]
     pub fn new(
@@ -59,7 +59,7 @@ impl<'a, 'b, A: AsRef<AccountView>> MintToChecked<'a, 'b, A> {
         mint_authority: &'a AccountView,
         amount: u64,
         decimals: u8,
-        multisig_signers: &'b [A],
+        multisig_signers: &'b [MultisigSigner],
     ) -> Self {
         Self {
             mint,

--- a/programs/token/src/instructions/revoke.rs
+++ b/programs/token/src/instructions/revoke.rs
@@ -20,16 +20,16 @@ use {
 ///   0. `[WRITE]` The source account.
 ///   1. `[]` The source account's multisignature owner.
 ///   2. `..2+M` `[SIGNER]` M signer accounts
-pub struct Revoke<'a, 'b, A: AsRef<AccountView>> {
+pub struct Revoke<'a, 'b, MultisigSigner: AsRef<AccountView>> {
     /// Source Account.
     pub source: &'a AccountView,
     ///  Source Owner Account.
     pub authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
 }
 
-impl<'a, 'b, A: AsRef<AccountView>> Revoke<'a, 'b, A> {
+impl<'a, 'b, MultisigSigner: AsRef<AccountView>> Revoke<'a, 'b, MultisigSigner> {
     /// Creates a new `Revoke` instruction with a single owner authority.
     #[inline(always)]
     pub fn new(source: &'a AccountView, authority: &'a AccountView) -> Self {
@@ -42,7 +42,7 @@ impl<'a, 'b, A: AsRef<AccountView>> Revoke<'a, 'b, A> {
     pub fn with_multisig_signers(
         source: &'a AccountView,
         authority: &'a AccountView,
-        multisig_signers: &'b [A],
+        multisig_signers: &'b [MultisigSigner],
     ) -> Self {
         Self {
             source,

--- a/programs/token/src/instructions/set_authority.rs
+++ b/programs/token/src/instructions/set_authority.rs
@@ -30,20 +30,20 @@ pub enum AuthorityType {
 ///   0. `[WRITE]` The mint or account to change the authority of.
 ///   1. `[]` The current multisignature authority of the mint or account.
 ///   2. `..2+M` `[SIGNER]` M signer accounts
-pub struct SetAuthority<'a, 'b, 'c, A: AsRef<AccountView>> {
+pub struct SetAuthority<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> {
     /// Account (Mint or Token)
     pub account: &'a AccountView,
     /// Authority of the Account.
     pub authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'c [A],
+    pub multisig_signers: &'c [MultisigSigner],
     /// The type of authority to update.
     pub authority_type: AuthorityType,
     /// The new authority
     pub new_authority: Option<&'b Address>,
 }
 
-impl<'a, 'b, 'c, A: AsRef<AccountView>> SetAuthority<'a, 'b, 'c, A> {
+impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> SetAuthority<'a, 'b, 'c, MultisigSigner> {
     /// Creates a new `SetAuthority` instruction with a single authority.
     #[inline(always)]
     pub fn new(
@@ -63,7 +63,7 @@ impl<'a, 'b, 'c, A: AsRef<AccountView>> SetAuthority<'a, 'b, 'c, A> {
         authority: &'a AccountView,
         authority_type: AuthorityType,
         new_authority: Option<&'b Address>,
-        multisig_signers: &'c [A],
+        multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token/src/instructions/thaw_account.rs
+++ b/programs/token/src/instructions/thaw_account.rs
@@ -22,7 +22,7 @@ use {
 ///   1. `[]` The token mint.
 ///   2. `[]` The mint's multisignature freeze authority.
 ///   3. `..3+M` `[SIGNER]` M signer accounts
-pub struct ThawAccount<'a, 'b, A: AsRef<AccountView>> {
+pub struct ThawAccount<'a, 'b, MultisigSigner: AsRef<AccountView>> {
     /// Token Account to thaw.
     pub account: &'a AccountView,
     /// Mint Account.
@@ -30,10 +30,10 @@ pub struct ThawAccount<'a, 'b, A: AsRef<AccountView>> {
     /// Mint Freeze Authority Account
     pub freeze_authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
 }
 
-impl<'a, 'b, A: AsRef<AccountView>> ThawAccount<'a, 'b, A> {
+impl<'a, 'b, MultisigSigner: AsRef<AccountView>> ThawAccount<'a, 'b, MultisigSigner> {
     /// Creates a new `ThawAccount` instruction with a single freeze authority.
     #[inline(always)]
     pub fn new(
@@ -51,7 +51,7 @@ impl<'a, 'b, A: AsRef<AccountView>> ThawAccount<'a, 'b, A> {
         account: &'a AccountView,
         mint: &'a AccountView,
         freeze_authority: &'a AccountView,
-        multisig_signers: &'b [A],
+        multisig_signers: &'b [MultisigSigner],
     ) -> Self {
         Self {
             account,

--- a/programs/token/src/instructions/transfer.rs
+++ b/programs/token/src/instructions/transfer.rs
@@ -22,7 +22,7 @@ use {
 ///   1. `[WRITE]` Recipient account
 ///   2. `[]` Authority account (multisig)
 ///   3. `..3+M` `[SIGNER]` M signer accounts
-pub struct Transfer<'a, 'b, A: AsRef<AccountView>> {
+pub struct Transfer<'a, 'b, MultisigSigner: AsRef<AccountView>> {
     /// Sender account.
     pub from: &'a AccountView,
     /// Recipient account.
@@ -30,12 +30,12 @@ pub struct Transfer<'a, 'b, A: AsRef<AccountView>> {
     /// Authority account.
     pub authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
     /// Amount of micro-tokens to transfer.
     pub amount: u64,
 }
 
-impl<'a, 'b, A: AsRef<AccountView>> Transfer<'a, 'b, A> {
+impl<'a, 'b, MultisigSigner: AsRef<AccountView>> Transfer<'a, 'b, MultisigSigner> {
     /// Creates a new `Transfer` instruction with a single
     /// owner/delegate authority.
     #[inline(always)]
@@ -56,7 +56,7 @@ impl<'a, 'b, A: AsRef<AccountView>> Transfer<'a, 'b, A> {
         to: &'a AccountView,
         authority: &'a AccountView,
         amount: u64,
-        multisig_signers: &'b [A],
+        multisig_signers: &'b [MultisigSigner],
     ) -> Self {
         Self {
             from,

--- a/programs/token/src/instructions/transfer_checked.rs
+++ b/programs/token/src/instructions/transfer_checked.rs
@@ -24,7 +24,7 @@ use {
 ///   2. `[WRITE]` The destination account.
 ///   3. `[]` The source account's multisignature owner/delegate.
 ///   4. `..4+M` `[SIGNER]` M signer accounts
-pub struct TransferChecked<'a, 'b, A: AsRef<AccountView>> {
+pub struct TransferChecked<'a, 'b, MultisigSigner: AsRef<AccountView>> {
     /// Sender account.
     pub from: &'a AccountView,
     /// Mint Account
@@ -34,14 +34,14 @@ pub struct TransferChecked<'a, 'b, A: AsRef<AccountView>> {
     /// Authority account.
     pub authority: &'a AccountView,
     /// Multisignature signers.
-    pub multisig_signers: &'b [A],
+    pub multisig_signers: &'b [MultisigSigner],
     /// Amount of micro-tokens to transfer.
     pub amount: u64,
     /// Decimal for the Token
     pub decimals: u8,
 }
 
-impl<'a, 'b, A: AsRef<AccountView>> TransferChecked<'a, 'b, A> {
+impl<'a, 'b, MultisigSigner: AsRef<AccountView>> TransferChecked<'a, 'b, MultisigSigner> {
     /// Creates a new `TransferChecked` instruction with a single
     /// owner/delegate authority.
     #[inline(always)]
@@ -66,7 +66,7 @@ impl<'a, 'b, A: AsRef<AccountView>> TransferChecked<'a, 'b, A> {
         authority: &'a AccountView,
         amount: u64,
         decimals: u8,
-        multisig_signers: &'b [A],
+        multisig_signers: &'b [MultisigSigner],
     ) -> Self {
         Self {
             from,


### PR DESCRIPTION
### Problem

Instruction helpers that require multisig signers currently specify them as `&[&AccountView]`. This has the drawback that if signers are extracted from the accounts slice as a `[AccountView]` slice, then they need to be mapped to a `[&AccountView]` slice.

### Solution

This PR add a generic type `A: AsRef<AccountView>` to specify signers. With this change, signers can be specific either as `&[&AccountView]` or `&[AccountView]`. This is particularly useful when signers are passed as "remaining" accounts – e.g.:
```rust
let [from, to, authority, signers @ ..] = accounts else {
    return Err(ProgramError::NotEnoughAccountKeys);
};

Transfer {
    from,
    to,
    authority,
    multisig_signers: signers,
    amount: 1_000_000_000,
}
.invoke()?;
```
The above example does not compile with the current version, but it will with the changes in this PR.