### PR TITLE
add decode as default features

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -25,12 +25,15 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 alloc = ["solana-instruction-view?/slice-cpi"]
 copy = ["solana-account-view/copy", "solana-address/copy"]
 cpi = ["dep:solana-instruction-view"]
-default = ["alloc"]
+decode = ["solana-address/decode"]
+default = ["alloc", "decode"]
 
 [dependencies]
 solana-account-view = { workspace = true }
 solana-address = { workspace = true, features = ["syscalls"] }
-solana-instruction-view = { workspace = true, features = ["cpi"], optional = true }
+solana-instruction-view = { workspace = true, features = [
+    "cpi",
+], optional = true }
 solana-program-error = { workspace = true }
 
 [target.'cfg(any(target_os = "solana", target_arch = "bpf"))'.dependencies]


### PR DESCRIPTION
Problem:

`pinocchio` depends on `solana-address`, but it does not re-export the `decode` feature as default nor as optional. Because of this, decoding-related functionality from `solana-address`, such as `Address::from_str_const` is not available when using `pinocchio`.

Solution:

Expose the `decode` feature in `pinocchio` and forward it to `solana-address`, and include it in the default features.