### PR TITLE
programs/system: Add cfg for resize features

### DIFF
--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -86,6 +86,7 @@ pub fn create_account_with_minimum_balance_signed(
         // Assign the account to the specified owner.
         Assign { account, owner }.invoke_signed(signers)?;
 
+        #[cfg(any(feature = "account-resize", feature = "unsafe-account-resize"))]
         // Allocate the required space for the account using the `AccountView::resize`.
         //
         // SAFETY: There are no active borrows of the `account`.


### PR DESCRIPTION
### Problem

PR #347 added `account-resize` and `unsafe-account-resize` features. For the `create_account_with_minimum_balance_signed`, when neither feature are enabled, the code ends up with an empty `unsafe {}` block.

### Solution

Add `#[cfg(any(feature = "account-resize", feature = "unsafe-account-resize"))]` so the unsafe block is only present if one of the resize features is enabled.