### PR TITLE
token, token-2022: Fix consistency in instructions

### DIFF
--- a/programs/token-2022/src/instructions/extensions/cpi_guard/disable.rs
+++ b/programs/token-2022/src/instructions/extensions/cpi_guard/disable.rs
@@ -1,6 +1,6 @@
 use {
     crate::instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
-    core::{mem::MaybeUninit, slice},
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -122,14 +122,12 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Disable<'a, 'b, 'c, Multisi
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
                 accounts: unsafe {
-                    slice::from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
+                    from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
                 },
                 data: &[ExtensionDiscriminator::CpiGuard as u8, Self::DISCRIMINATOR],
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/cpi_guard/enable.rs
+++ b/programs/token-2022/src/instructions/extensions/cpi_guard/enable.rs
@@ -1,6 +1,6 @@
 use {
     crate::instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
-    core::{mem::MaybeUninit, slice},
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -126,14 +126,12 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Enable<'a, 'b, 'c, Multisig
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
                 accounts: unsafe {
-                    slice::from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
+                    from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
                 },
                 data: &[ExtensionDiscriminator::CpiGuard as u8, Self::DISCRIMINATOR],
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/default_account_state/update.rs
+++ b/programs/token-2022/src/instructions/extensions/default_account_state/update.rs
@@ -3,7 +3,7 @@ use {
         instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
         state::AccountState,
     },
-    core::{mem::MaybeUninit, slice},
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -131,7 +131,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, Multisig
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
                 accounts: unsafe {
-                    slice::from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
+                    from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
                 },
                 data: &[
                     ExtensionDiscriminator::DefaultAccountState as u8,
@@ -140,9 +140,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, Multisig
                 ],
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/group_member_pointer/update.rs
+++ b/programs/token-2022/src/instructions/extensions/group_member_pointer/update.rs
@@ -3,10 +3,7 @@ use {
         instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
         write_bytes, UNINIT_BYTE,
     },
-    core::{
-        mem::MaybeUninit,
-        slice::{self, from_raw_parts},
-    },
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -150,7 +147,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, Multisig
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
                 accounts: unsafe {
-                    slice::from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
+                    from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
                 },
                 // SAFETY: instruction data is initialized.
                 data: unsafe {
@@ -158,9 +155,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, Multisig
                 },
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/group_pointer/update.rs
+++ b/programs/token-2022/src/instructions/extensions/group_pointer/update.rs
@@ -3,10 +3,7 @@ use {
         instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
         write_bytes, UNINIT_BYTE,
     },
-    core::{
-        mem::MaybeUninit,
-        slice::{self, from_raw_parts},
-    },
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -150,7 +147,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, Multisig
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
                 accounts: unsafe {
-                    slice::from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
+                    from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
                 },
                 // SAFETY: instruction data is initialized.
                 data: unsafe {
@@ -158,9 +155,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, Multisig
                 },
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/interest_bearing_mint/update.rs
+++ b/programs/token-2022/src/instructions/extensions/interest_bearing_mint/update.rs
@@ -3,10 +3,7 @@ use {
         instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
         write_bytes, UNINIT_BYTE,
     },
-    core::{
-        mem::MaybeUninit,
-        slice::{self, from_raw_parts},
-    },
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -151,9 +148,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, Multisig
                 },
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/memo_transfer/disable.rs
+++ b/programs/token-2022/src/instructions/extensions/memo_transfer/disable.rs
@@ -1,6 +1,6 @@
 use {
     crate::instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
-    core::{mem::MaybeUninit, slice},
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -122,7 +122,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Disable<'a, 'b, 'c, Multisi
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
                 accounts: unsafe {
-                    slice::from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
+                    from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
                 },
                 data: &[
                     ExtensionDiscriminator::MemoTransfer as u8,
@@ -130,9 +130,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Disable<'a, 'b, 'c, Multisi
                 ],
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/memo_transfer/enable.rs
+++ b/programs/token-2022/src/instructions/extensions/memo_transfer/enable.rs
@@ -1,6 +1,6 @@
 use {
     crate::instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
-    core::{mem::MaybeUninit, slice},
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -119,7 +119,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Enable<'a, 'b, 'c, Multisig
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
                 accounts: unsafe {
-                    slice::from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
+                    from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
                 },
                 data: &[
                     ExtensionDiscriminator::MemoTransfer as u8,
@@ -127,9 +127,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Enable<'a, 'b, 'c, Multisig
                 ],
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/metadata_pointer/update.rs
+++ b/programs/token-2022/src/instructions/extensions/metadata_pointer/update.rs
@@ -3,10 +3,7 @@ use {
         instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
         write_bytes, UNINIT_BYTE,
     },
-    core::{
-        mem::MaybeUninit,
-        slice::{self, from_raw_parts},
-    },
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -150,7 +147,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, Multisig
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
                 accounts: unsafe {
-                    slice::from_raw_parts(
+                    from_raw_parts(
                         instruction_accounts.as_ptr() as *const InstructionAccount,
                         expected_accounts,
                     )
@@ -161,9 +158,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Update<'a, 'b, 'c, Multisig
                 },
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/pausable/pause.rs
+++ b/programs/token-2022/src/instructions/extensions/pausable/pause.rs
@@ -1,6 +1,6 @@
 use {
     crate::instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
-    core::{mem::MaybeUninit, slice},
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -119,14 +119,12 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Pause<'a, 'b, 'c, MultisigS
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
                 accounts: unsafe {
-                    slice::from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
+                    from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
                 },
                 data: &[ExtensionDiscriminator::Pausable as u8, Self::DISCRIMINATOR],
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/pausable/resume.rs
+++ b/programs/token-2022/src/instructions/extensions/pausable/resume.rs
@@ -1,6 +1,6 @@
 use {
     crate::instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
-    core::{mem::MaybeUninit, slice},
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -119,14 +119,12 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Resume<'a, 'b, 'c, Multisig
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
                 accounts: unsafe {
-                    slice::from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
+                    from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
                 },
                 data: &[ExtensionDiscriminator::Pausable as u8, Self::DISCRIMINATOR],
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/permissioned_burn/burn.rs
+++ b/programs/token-2022/src/instructions/extensions/permissioned_burn/burn.rs
@@ -3,10 +3,7 @@ use {
         instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
         write_bytes, UNINIT_BYTE,
     },
-    core::{
-        mem::MaybeUninit,
-        slice::{self, from_raw_parts},
-    },
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -186,9 +183,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> Burn<'a, 'b, 'c, MultisigSi
                 },
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/permissioned_burn/burn_checked.rs
+++ b/programs/token-2022/src/instructions/extensions/permissioned_burn/burn_checked.rs
@@ -3,10 +3,7 @@ use {
         instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
         write_bytes, UNINIT_BYTE,
     },
-    core::{
-        mem::MaybeUninit,
-        slice::{self, from_raw_parts},
-    },
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -197,9 +194,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> BurnChecked<'a, 'b, 'c, Mul
                 },
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/scaled_ui_amount/update_multiplier.rs
+++ b/programs/token-2022/src/instructions/extensions/scaled_ui_amount/update_multiplier.rs
@@ -3,10 +3,7 @@ use {
         instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
         write_bytes, UNINIT_BYTE,
     },
-    core::{
-        mem::MaybeUninit,
-        slice::{self, from_raw_parts},
-    },
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -175,9 +172,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>> UpdateMultiplier<'a, 'b, 'c
                 },
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/extensions/transfer_fee/harvest_withheld_tokens_to_mint.rs
+++ b/programs/token-2022/src/instructions/extensions/transfer_fee/harvest_withheld_tokens_to_mint.rs
@@ -68,7 +68,7 @@ impl<Source: AsRef<AccountView>> HarvestWithheldTokensToMint<'_, '_, '_, Source>
             account.write(source.as_ref());
         }
 
-        invoke_with_bounds::<MAX_STATIC_CPI_ACCOUNTS, &AccountView>(
+        invoke_with_bounds::<MAX_STATIC_CPI_ACCOUNTS, _>(
             &InstructionView {
                 program_id: self.token_program,
                 // SAFETY: instruction accounts has `expected_accounts` initialized.
@@ -81,7 +81,7 @@ impl<Source: AsRef<AccountView>> HarvestWithheldTokensToMint<'_, '_, '_, Source>
                 ],
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe { from_raw_parts(accounts.as_ptr() as _, expected_accounts) },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
         )
     }
 }

--- a/programs/token-2022/src/instructions/extensions/transfer_hook/update.rs
+++ b/programs/token-2022/src/instructions/extensions/transfer_hook/update.rs
@@ -3,10 +3,7 @@ use {
         instructions::{extensions::ExtensionDiscriminator, MAX_MULTISIG_SIGNERS},
         write_bytes, UNINIT_BYTE,
     },
-    core::{
-        mem::MaybeUninit,
-        slice::{self, from_raw_parts},
-    },
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
@@ -170,9 +167,7 @@ impl<'a, 'b, 'c, MultisigSigner: AsRef<AccountView>>
                 },
             },
             // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe {
-                slice::from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts)
-            },
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
             signers,
         )
     }

--- a/programs/token-2022/src/instructions/initialize_multisig.rs
+++ b/programs/token-2022/src/instructions/initialize_multisig.rs
@@ -1,5 +1,5 @@
 use {
-    core::{mem::MaybeUninit, slice},
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{cpi::invoke_with_bounds, InstructionAccount, InstructionView},
@@ -79,9 +79,7 @@ impl<MultisigSigner: AsRef<AccountView>> InitializeMultisig<'_, '_, '_, Multisig
 
         let instruction = InstructionView {
             program_id: token_program,
-            accounts: unsafe {
-                slice::from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts)
-            },
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts) },
             data,
         };
 
@@ -102,8 +100,8 @@ impl<MultisigSigner: AsRef<AccountView>> InitializeMultisig<'_, '_, '_, Multisig
             account_view.write(signer.as_ref());
         }
 
-        invoke_with_bounds::<{ 2 + MAX_MULTISIG_SIGNERS }, &AccountView>(&instruction, unsafe {
-            slice::from_raw_parts(acc_views.as_ptr() as _, num_accounts)
+        invoke_with_bounds::<{ 2 + MAX_MULTISIG_SIGNERS }, _>(&instruction, unsafe {
+            from_raw_parts(acc_views.as_ptr() as *const &AccountView, num_accounts)
         })
     }
 }

--- a/programs/token-2022/src/instructions/initialize_multisig_2.rs
+++ b/programs/token-2022/src/instructions/initialize_multisig_2.rs
@@ -1,6 +1,6 @@
 use {
     crate::instructions::MAX_MULTISIG_SIGNERS,
-    core::{mem::MaybeUninit, slice},
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{cpi::invoke_with_bounds, InstructionAccount, InstructionView},
@@ -70,9 +70,7 @@ impl<MultisigSigner: AsRef<AccountView>> InitializeMultisig2<'_, '_, '_, Multisi
 
         let instruction = InstructionView {
             program_id: token_program,
-            accounts: unsafe {
-                slice::from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts)
-            },
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts) },
             data,
         };
 
@@ -92,8 +90,8 @@ impl<MultisigSigner: AsRef<AccountView>> InitializeMultisig2<'_, '_, '_, Multisi
             account_view.write(signer.as_ref());
         }
 
-        invoke_with_bounds::<{ 1 + MAX_MULTISIG_SIGNERS }, &AccountView>(&instruction, unsafe {
-            slice::from_raw_parts(acc_views.as_ptr() as _, num_accounts)
+        invoke_with_bounds::<{ 1 + MAX_MULTISIG_SIGNERS }, _>(&instruction, unsafe {
+            from_raw_parts(acc_views.as_ptr() as *const &AccountView, num_accounts)
         })
     }
 }

--- a/programs/token/src/instructions/initialize_multisig.rs
+++ b/programs/token/src/instructions/initialize_multisig.rs
@@ -1,5 +1,5 @@
 use {
-    core::{mem::MaybeUninit, slice},
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_instruction_view::{cpi::invoke_with_bounds, InstructionAccount, InstructionView},
     solana_program_error::{ProgramError, ProgramResult},
@@ -75,9 +75,7 @@ impl<MultisigSigner: AsRef<AccountView>> InitializeMultisig<'_, '_, MultisigSign
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: unsafe {
-                slice::from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts)
-            },
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts) },
             data,
         };
 
@@ -98,8 +96,8 @@ impl<MultisigSigner: AsRef<AccountView>> InitializeMultisig<'_, '_, MultisigSign
             account_view.write(signer.as_ref());
         }
 
-        invoke_with_bounds::<{ 2 + MAX_MULTISIG_SIGNERS }, &AccountView>(&instruction, unsafe {
-            slice::from_raw_parts(acc_views.as_ptr() as _, num_accounts)
+        invoke_with_bounds::<{ 2 + MAX_MULTISIG_SIGNERS }, _>(&instruction, unsafe {
+            from_raw_parts(acc_views.as_ptr() as *const &AccountView, num_accounts)
         })
     }
 }

--- a/programs/token/src/instructions/initialize_multisig_2.rs
+++ b/programs/token/src/instructions/initialize_multisig_2.rs
@@ -1,6 +1,6 @@
 use {
     crate::instructions::MAX_MULTISIG_SIGNERS,
-    core::{mem::MaybeUninit, slice},
+    core::{mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
     solana_instruction_view::{cpi::invoke_with_bounds, InstructionAccount, InstructionView},
     solana_program_error::{ProgramError, ProgramResult},
@@ -66,9 +66,7 @@ impl<MultisigSigner: AsRef<AccountView>> InitializeMultisig2<'_, '_, MultisigSig
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: unsafe {
-                slice::from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts)
-            },
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts) },
             data,
         };
 
@@ -88,8 +86,8 @@ impl<MultisigSigner: AsRef<AccountView>> InitializeMultisig2<'_, '_, MultisigSig
             account_view.write(signer.as_ref());
         }
 
-        invoke_with_bounds::<{ 1 + MAX_MULTISIG_SIGNERS }, &AccountView>(&instruction, unsafe {
-            slice::from_raw_parts(acc_views.as_ptr() as _, num_accounts)
+        invoke_with_bounds::<{ 1 + MAX_MULTISIG_SIGNERS }, _>(&instruction, unsafe {
+            from_raw_parts(acc_views.as_ptr() as *const &AccountView, num_accounts)
         })
     }
 }


### PR DESCRIPTION
1. Changed `&AccountView` to `_` in places missed in #363.
2. While doing that, I noticed that `from_raw_parts` is called differently in different instructions: in some `from_raw_parts`, in some `slice::from_raw_parts`, and in some both variants are used. Changed to `from_raw_parts` everywhere.

There are also `core::slice::from_raw_parts` in `Memo` and `sdk`, but I'm not sure if they need to be fixed. 