### PR TITLE
workspace: Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
  "pinocchio",
  "solana-account-view",
  "solana-address",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.0.0",
  "solana-instruction-view",
  "solana-program-error",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,10 @@ repository = "https://github.com/anza-xyz/pinocchio"
 rust-version = "1.84"
 
 [workspace.dependencies]
-five8_const = "0.1.4"
 pinocchio = { version = "0.10", default-features = false, path = "sdk" }
 solana-account-view = "2.0"
 solana-address = "2.0"
-solana-define-syscall = "4.0"
+solana-define-syscall = "5.0"
 solana-instruction-view = "2.0"
 solana-program-error = "3.0"
 


### PR DESCRIPTION
### Problem

`five8_const` still listed as a workspace dependency, but it is not used by any of the crates directly. Also, the updated `solana-instruction-view` crate is using `solana-define-syscall` version `5.0` while the workspace is using `4.0`.

### Solution

Remove `five8_const` and bump `solana-define-syscall` version to `5.0`.