### PR TITLE
v0.9: Fix maximum transaction accounts constant value

### DIFF
--- a/sdk/pinocchio/src/lib.rs
+++ b/sdk/pinocchio/src/lib.rs
@@ -243,14 +243,14 @@ pub use entrypoint::lazy as lazy_entrypoint;
 
 /// Maximum number of accounts that a transaction may process.
 ///
-/// This value is set to `u8::MAX - 1`, which is the theoretical maximum
+/// This value is set to `u8::MAX`, which is the theoretical maximum
 /// number of accounts that a transaction can process given that indices
 /// of accounts are represented by an `u8` value and the last
 /// value (`255`) is reserved to indicate non-duplicated accounts.
 ///
 /// The `MAX_TX_ACCOUNTS` is used to statically initialize the array of
 /// `AccountInfo`s when parsing accounts in an instruction.
-pub const MAX_TX_ACCOUNTS: usize = (u8::MAX - 1) as usize;
+pub const MAX_TX_ACCOUNTS: usize = u8::MAX as usize;
 
 /// `assert_eq(core::mem::align_of::<u128>(), 8)` is true for BPF but not
 /// for some host machines.


### PR DESCRIPTION
### Problem

Currently the [`MAX_TX_ACCOUNTS`](https://github.com/anza-xyz/pinocchio/blob/maintenance/v0.9.x/sdk/pinocchio/src/lib.rs#L253) constant value is not set correctly – its value should match [`MAX_ACCOUNTS_PER_INSTRUCTION`](https://github.com/anza-xyz/agave/blob/5a13e3f9a3b8d1ebe9722f7c267bfecb89beaf0a/transaction-context/src/lib.rs#L17).

### Solution

Fix the value.