### PR TITLE
v0.9: ci: Pin cargo-semver-checks version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -89,7 +89,7 @@ runs:
       if: ${{ contains(inputs.components, 'semver-checks') }}
       uses: taiki-e/install-action@v2
       with:
-        tool: cargo-semver-checks
+        tool: cargo-semver-checks@0.41.0
 
     - name: Install 'cargo-miri'
       if: ${{ contains(inputs.toolchain, 'lint') }}


### PR DESCRIPTION
### Problem

Currently it is not possible to publish crates from the maintenance v0.9 branch since the latest cargo-semver-checks required a higher MSRV.

### Solution

Pin cargo-semver-checks to a more recent version that supports Rust `1.84.1`.