### PR TITLE
v0.9: Remove `no_mangle` attribute

### DIFF
--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -487,7 +487,6 @@ macro_rules! nostd_panic_handler {
     () => {
         /// A panic handler for `no_std`.
         #[cfg(target_os = "solana")]
-        #[no_mangle]
         #[panic_handler]
         fn handler(info: &core::panic::PanicInfo<'_>) -> ! {
             if let Some(location) = info.location() {


### PR DESCRIPTION
### Problem

Newer versions of the Rust compiler do not allow using "no_mangle" attribute on internal language items, such as `#[panic_handler]`.

### Solution

Remove the `#[no_mangle]` attribute from the `nostd_panic_handler` macro.