### PR TITLE
Update crate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The `alloc` feature is enabled by default and it uses the [`alloc`](https://doc.
 When no allocation is needed or desired, the feature can be disabled:
 
 ```
-pinocchio = { version = "0.11.0", default-features = false }
+pinocchio = { version = "0.11", default-features = false }
 ```
 
 > ⚠️ **Note:**
@@ -247,7 +247,7 @@ on the `solana-account-view` and `solana-address` re-exports.
 The `cpi` feature enables the cross-program invocation helpers, as well as types to define instructions and signer information.
 
 ```
-pinocchio = { version = "0.11.0", features = ["cpi"] }
+pinocchio = { version = "0.11", features = ["cpi"] }
 ```
 
 ### `account-resize`
@@ -296,7 +296,7 @@ program's `Cargo.toml`:
 ```
 [dependencies]
 # Enable static syscalls for BPF target
-solana-define-syscall = { version = "4.0.1", features = ["unstable-static-syscalls"] }
+solana-define-syscall = { version = "5.0", features = ["unstable-static-syscalls"] }
 ```
 
 When compiling your program with the upstream BPF target, the `std` library is not available. Therefore, the program crate must include the `#![no_std]` crate-level attribute and use the `nostd_panic_handler!` macro. An allocator may be used as long as `alloc` is used.

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -253,7 +253,7 @@
 //!
 //! When no allocation is needed or desired, the feature can be disabled:
 //! ```ignore
-//! pinocchio = { version = "0.11.0", default-features = false }
+//! pinocchio = { version = "0.11", default-features = false }
 //! ```
 //!
 //! ### `copy`
@@ -267,7 +267,7 @@
 //! The `cpi` feature enables the cross-program invocation helpers, as well as
 //! types to define instructions and signer information.
 //! ```ignore
-//! pinocchio = { version = "0.11.0", features = ["cpi"] }
+//! pinocchio = { version = "0.11", features = ["cpi"] }
 //! ```
 //!
 //! ### `account-resize`
@@ -330,7 +330,7 @@
 //! ```toml
 //! [dependencies]
 //! # Enable static syscalls for BPF target
-//! solana-define-syscall = { version = "4.0.1", features = ["unstable-static-syscalls"] }
+//! solana-define-syscall = { version = "5.0", features = ["unstable-static-syscalls"] }
 //! ```
 //!
 //! When compiling your program with the upstream BPF target, the `std` library


### PR DESCRIPTION
### Problem

The crate documentation and readme still reference `v0.10` and do not include the new crate features.

### Solution

Update both in preparation for the new release.