### PR TITLE
sdk: Add inline program entrypoint

### DIFF
--- a/sdk/src/entrypoint/inline.rs
+++ b/sdk/src/entrypoint/inline.rs
@@ -16,25 +16,27 @@ pub const MAX_INLINE_ACCOUNTS: usize = 10;
 /// This allows the entrypoint to read the instruction data and decide how many
 /// accounts it wants to parse from the program input.
 ///
-/// It offers two macros to declare the entrypoint: [`inline_program_entrypoint`]
-/// and [`execute`]. The former is used to declare the entrypoint and the
-/// latter is used to execute the program logic with a specified number of
-/// accounts and a processor function. The processor function is called with
-/// the program id, the accounts, and the instruction data.
+/// It offers two macros to declare the entrypoint:
+/// [`crate::inline_program_entrypoint!`] and [`crate::execute!`]. The former is
+/// used to declare the entrypoint and the latter is used to execute the program
+/// logic with a specified number of accounts and a processor function. The
+/// processor function is called with the program id, the accounts, and the
+/// instruction data.
 ///
-/// The [`inline_program_entrypoint`] macro is used to declare the entrypoint. The
-/// only argument is the name of a function with this type signature:
+/// The [`crate::inline_program_entrypoint!`] macro is used to declare the
+/// entrypoint. The only argument is the name of a function with this type
+/// signature:
 ///
 /// ```ignore
 /// fn process_instruction(input: ProgramInput) -> ProgramResult;
 /// ```
 ///
 /// [`ProgramInput`] offers a method to read the instruction data. Programs can
-/// then use the [`execute`] macro to execute the program logic for the
-/// corresponding instruction. The [`execute`] macro takes three arguments: the
-/// number of accounts to parse from the input buffer, the program input, and
-/// the name of the processor function. The processor function has this type
-/// signature:
+/// then use the [`crate::execute!`] macro to execute the program logic for the
+/// corresponding instruction. The [`crate::execute!`] macro takes three
+/// arguments: the number of accounts to parse from the input buffer, the
+/// program input, and the name of the processor function. The processor
+/// function has this type signature:
 ///
 /// ```ignore
 /// fn processor(

--- a/sdk/src/entrypoint/inline.rs
+++ b/sdk/src/entrypoint/inline.rs
@@ -1,0 +1,264 @@
+//! Defines the inline program entrypoint and associated types.
+
+use {core::slice::from_raw_parts, solana_address::Address};
+
+/// Maximum number of accounts that can be parsed inline in the entrypoint.
+///
+/// This is a hard limit to constrain the size of the parsing logic
+/// inlined in the entrypoint.
+pub const MAX_INLINE_ACCOUNTS: usize = 10;
+
+/// Declare the inline program entrypoint.
+///
+/// This entrypoint is defined as *inline* because it inlines the account
+/// parsing logic into the entrypoint itself. It takes advantage of the fact
+/// that the runtime passes the instruction data pointer to the entrypoint.
+/// This allows the entrypoint to read the instruction data and decide how many
+/// accounts it wants to parse from the program input.
+///
+/// It offers two macros to declare the entrypoint: [`inline_program_entrypoint`]
+/// and [`execute`]. The former is used to declare the entrypoint and the
+/// latter is used to execute the program logic with a specified number of
+/// accounts and a processor function. The processor function is called with
+/// the program id, the accounts, and the instruction data.
+///
+/// The [`inline_program_entrypoint`] macro is used to declare the entrypoint. The
+/// only argument is the name of a function with this type signature:
+///
+/// ```ignore
+/// fn process_instruction(input: ProgramInput) -> ProgramResult;
+/// ```
+///
+/// [`ProgramInput`] offers a method to read the instruction data. Programs can
+/// then use the [`execute`] macro to execute the program logic for the
+/// corresponding instruction. The [`execute`] macro takes three arguments: the
+/// number of accounts to parse from the input buffer, the program input, and
+/// the name of the processor function. The processor function has this type
+/// signature:
+///
+/// ```ignore
+/// fn processor(
+///     program_id: &Address,
+///     accounts: &mut [AccountView],
+///     instruction_data: &[u8]
+///  ) -> ProgramResult;
+/// ```
+///
+/// # Example
+///
+/// Defining an entrypoint and making it conditional on the `bpf-entrypoint`
+/// feature. Although the `entrypoint` module is written inline in this example,
+/// it is common to put it into its own file.
+///
+/// ```no_run
+/// #[cfg(feature = "bpf-entrypoint")]
+/// pub mod entrypoint {
+///     use {
+///         pinocchio::{
+///             entrypoint::inline::ProgramInput, error::ProgramError, execute,
+///             inline_program_entrypoint, AccountView, Address, ProgramResult,
+///         },
+///         pinocchio_system::instructions::CreateAccount,
+///     };
+///
+///     // Declares the entrypoint of the program.
+///     inline_program_entrypoint!(process_instruction);
+///
+///     pub fn process_instruction(input: ProgramInput) -> ProgramResult {
+///         match input.data.first() {
+///            Some(&0) => execute!((3, input) => create),
+///            _ => return Err(ProgramError::InvalidInstructionData),
+///        }
+///     }
+///
+///     /// Instruction processor.
+///     pub fn create(
+///         program_id: &Address,
+///         accounts: &mut [AccountView],
+///         _instruction_data: &[u8],
+///     ) -> ProgramResult {
+///         let [from, to, _system_program] = accounts else {
+///             return Err(ProgramError::NotEnoughAccountKeys);
+///         };
+///
+///         CreateAccount {
+///             from,
+///             to,
+///             lamports: 1_000_000_000,
+///             space: 10,
+///             owner: program_id,
+///         }
+///         .invoke()
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! inline_program_entrypoint {
+    ( $process_instruction:expr ) => {
+        /// Program entrypoint.
+        #[no_mangle]
+        pub unsafe extern "C" fn entrypoint(
+            program_input: *mut u8,
+            instruction_data: *const u8,
+        ) -> u64 {
+            match $process_instruction($crate::entrypoint::inline::ProgramInput::new_unchecked(
+                program_input,
+                instruction_data,
+            )) {
+                Ok(_) => $crate::SUCCESS,
+                Err(error) => error.into(),
+            }
+        }
+    };
+}
+
+/// Representation of the program input parameters passed by the runtime to the
+/// entrypoint.
+#[derive(Debug)]
+pub struct ProgramInput {
+    /// The data for the instruction.
+    pub data: &'static [u8],
+
+    /// Pointer to the runtime input buffer to read from.
+    pub raw: *mut u8,
+
+    /// Number of available accounts.
+    pub available: u64,
+}
+
+impl ProgramInput {
+    /// Creates a new [`ProgramInput`] for the input buffer.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that both `program_input` and `instruction_data`
+    /// are valid pointers to the correct locations in the input buffer as
+    /// serialized by the SVM loader. The `program_input` pointer should point
+    /// to the start of the input buffer, and the `instruction_data` pointer
+    /// should point to the start of the instruction data within that buffer.
+    #[inline(always)]
+    pub unsafe fn new_unchecked(program_input: *mut u8, instruction_data: *const u8) -> Self {
+        // SAFETY: The 8 bytes preceding the instruction data represent the instruction
+        // data length.
+        let length =
+            unsafe { *(instruction_data.sub(::core::mem::size_of::<u64>()) as *const u64) };
+
+        Self {
+            data: unsafe { from_raw_parts(instruction_data, length as usize) },
+            // SAFETY: Account data is located after the first 8 bytes on the program input.
+            raw: unsafe { program_input.add(::core::mem::size_of::<u64>()) },
+            // SAFETY: The number of accounts is serialized at the start of the program
+            // input buffer by the SVM loader.
+            available: unsafe { *(program_input as *const u64) },
+        }
+    }
+
+    /// Return the address of the program.
+    pub fn program_id(&self) -> &'static Address {
+        // SAFETY: The program id is located at the end of the program input buffer
+        // serialized by the SVM loader after the instruction data.
+        unsafe { &*self.data.as_ptr().add(self.data.len()).cast::<Address>() }
+    }
+}
+
+#[macro_export]
+macro_rules! execute {
+    ( (1, $context:expr) => $processor:expr ) => {{
+        if $context.available < 1 {
+            return $crate::error::ProgramError::NotEnoughAccountKeys;
+        }
+
+        let mut accounts = [const { ::core::mem::MaybeUninit::<$crate::AccountView>::uninit() }; $crate::MAX_TX_ACCOUNTS];
+
+        let mut ptr = accounts.as_mut_ptr() as *mut $crate::AccountView;
+        let accounts_slice = ptr;
+
+        let mut input = $context.raw;
+
+        let account = input as *mut $crate::account::RuntimeAccount;
+
+        // SAFETY: First account is always non-duplicated.
+        unsafe {
+            $crate::__store_data_length_in_padding!(account);
+            ptr.write($crate::AccountView::new_unchecked(account));
+
+            input = input.add(size_of::<u64>());
+            $crate::__advance_input_with_account!(input, account);
+        }
+
+        let accounts = unsafe {
+            ::core::slice::from_raw_parts_mut(accounts.as_mut_ptr() as *mut $crate::AccountView, 1)
+        };
+
+        $processor($context.program_id(), accounts, $context.data)
+    }};
+
+    ( (2, $context:expr) => $processor:expr ) => {
+        $crate::execute!(@impl 2, 1, $context, $processor)
+    };
+
+    ( (3, $context:expr) => $processor:expr) => {
+        $crate::execute!(@impl 3, 2, $context, $processor)
+    };
+
+    ( (4, $context:expr) => $processor:expr ) => {
+        $crate::execute!(@impl 4, 3, $context, $processor)
+    };
+
+    ( (5, $context:expr) => $processor:expr) => {
+        $crate::execute!(@impl 5, 4, $context, $processor)
+    };
+
+    ( (6, $context:expr) => $processor:expr) => {
+        $crate::execute!(@impl 6, 5, $context, $processor)
+    };
+
+    ( (7, $context:expr) => $processor:expr) => {
+        $crate::execute!(@impl 7, 6, $context, $processor)
+    };
+
+    ( (8, $context:expr) => $processor:expr) => {
+        $crate::execute!(@impl 8, 7, $context, $processor)
+    };
+
+    ( (9, $context:expr) => $processor:expr) => {
+        $crate::execute!(@impl 9, 8, $context, $processor)
+    };
+
+    ( (10, $context:expr) => $processor:expr) => {
+        $crate::execute!(@impl 10, 9, $context, $processor)
+    };
+
+    // Shared implementation
+    (@impl $n:tt, $remaining:tt, $context:expr, $processor:expr) => {{
+        if $crate::hint::unlikely($context.available < $n) {
+            return Err($crate::error::ProgramError::NotEnoughAccountKeys);
+        }
+
+        let mut accounts = [const { ::core::mem::MaybeUninit::<$crate::AccountView>::uninit() }; $crate::MAX_TX_ACCOUNTS];
+
+        let mut ptr = accounts.as_mut_ptr() as *mut $crate::AccountView;
+        let accounts_slice = ptr;
+
+        let mut input = $context.raw;
+
+        let account = input as *mut $crate::account::RuntimeAccount;
+
+        // SAFETY: First account is always non-duplicated.
+        unsafe {
+            $crate::__store_data_length_in_padding!(account);
+            ptr.write($crate::AccountView::new_unchecked(account));
+
+            input = input.add(size_of::<u64>());
+            $crate::__advance_input_with_account!(input, account);
+
+            $crate::__process_accounts!($remaining => (input, ptr, accounts_slice));
+        }
+
+        let accounts = unsafe {
+            ::core::slice::from_raw_parts_mut(accounts.as_mut_ptr() as *mut $crate::AccountView, $n)
+        };
+
+        $processor($context.program_id(), accounts, $context.data)
+    }};
+}

--- a/sdk/src/entrypoint/mod.rs
+++ b/sdk/src/entrypoint/mod.rs
@@ -57,6 +57,7 @@
 //! └─ 32 bytes: address of the program account
 //! ```
 
+pub mod inline;
 pub mod lazy;
 
 #[cfg(feature = "alloc")]
@@ -65,13 +66,12 @@ pub use lazy::{InstructionContext, MaybeAccount};
 use {
     crate::{
         account::{AccountView, RuntimeAccount, MAX_PERMITTED_DATA_INCREASE},
-        Address, ProgramResult, BPF_ALIGN_OF_U128, MAX_TX_ACCOUNTS, SUCCESS,
+        Address, ProgramResult, MAX_TX_ACCOUNTS, SUCCESS,
     },
     core::{
         alloc::{GlobalAlloc, Layout},
         cmp::min,
         mem::{size_of, MaybeUninit},
-        ptr::with_exposed_provenance_mut,
         slice::{from_raw_parts, from_raw_parts_mut},
     },
 };
@@ -93,7 +93,7 @@ pub const NON_DUP_MARKER: u8 = u8::MAX;
 ///
 /// This is the size of the account header plus the maximum permitted data
 /// increase.
-const STATIC_ACCOUNT_DATA: usize = size_of::<RuntimeAccount>() + MAX_PERMITTED_DATA_INCREASE;
+pub const STATIC_ACCOUNT_DATA: usize = size_of::<RuntimeAccount>() + MAX_PERMITTED_DATA_INCREASE;
 
 /// Declare the program entrypoint and set up global handlers.
 ///
@@ -270,15 +270,17 @@ pub unsafe fn process_entrypoint<const MAX_ACCOUNTS: usize>(
 }
 
 /// Align a pointer to the BPF alignment of [`u128`].
-macro_rules! align_pointer {
+#[macro_export]
+macro_rules! __align_pointer {
     ($ptr:ident) => {
         // Integer-to-pointer cast: first compute the aligned address as a `usize`,
         // since this is more CU-efficient than using `ptr::align_offset()` or the
         // strict provenance API (e.g., `ptr::with_addr()`). Then cast the result
         // back to a pointer. The resulting pointer is guaranteed to be valid
         // because it follows the layout serialized by the runtime.
-        with_exposed_provenance_mut(
-            ($ptr.expose_provenance() + (BPF_ALIGN_OF_U128 - 1)) & !(BPF_ALIGN_OF_U128 - 1),
+        core::ptr::with_exposed_provenance_mut(
+            ($ptr.expose_provenance() + ($crate::BPF_ALIGN_OF_U128 - 1))
+                & !($crate::BPF_ALIGN_OF_U128 - 1),
         )
     };
 }
@@ -286,13 +288,32 @@ macro_rules! align_pointer {
 /// Advance the input pointer in relation to a non-duplicated account.
 ///
 /// The macro will add `STATIC_ACCOUNT_DATA` and the account length to
-/// the input pointer and align its address using [`align_pointer`].
-macro_rules! advance_input_with_account {
+/// the input pointer and align its address using [`__align_pointer`].
+#[macro_export]
+macro_rules! __advance_input_with_account {
     ($input:ident, $account:expr) => {{
-        $input = $input.add(STATIC_ACCOUNT_DATA);
+        $input = $input.add($crate::entrypoint::STATIC_ACCOUNT_DATA);
         $input = $input.add((*$account).data_len as usize);
-        $input = align_pointer!($input);
+        $input = $crate::__align_pointer!($input);
     }};
+}
+
+#[cfg(feature = "account-resize")]
+/// Store the data length in the `padding` field of an account.
+#[macro_export]
+macro_rules! __store_data_length_in_padding {
+    ($account:expr) => {{
+        // Stores the data length in the `padding` field. This is needed
+        // to handle account resizing.
+        (*$account).padding = u32::to_le_bytes((*$account).data_len as u32);
+    }};
+}
+
+#[cfg(not(feature = "account-resize"))]
+/// Placeholder macro when the `account-resize` feature is not enabled.
+#[macro_export]
+macro_rules! __store_data_length_in_padding {
+    ($account:expr) => {};
 }
 
 /// A macro to repeat a pattern to process an account `n` times, where `n` is
@@ -304,14 +325,15 @@ macro_rules! advance_input_with_account {
 ///
 /// Note that this macro emits code to update both the `input` and `accounts`
 /// pointers.
-macro_rules! process_n_accounts {
+#[macro_export]
+macro_rules! __process_n_accounts {
     // Base case: no tokens left.
     ( () => ( $input:ident, $accounts:ident, $accounts_slice:ident ) ) => {};
 
     // Recursive case: one `_` token per repetition.
     ( ( _ $($rest:tt)* ) => ( $input:ident, $accounts:ident, $accounts_slice:ident ) ) => {
-        process_n_accounts!(@process_account => ($input, $accounts, $accounts_slice));
-        process_n_accounts!(($($rest)*) => ($input, $accounts, $accounts_slice));
+        $crate::__process_n_accounts!(@process_account => ($input, $accounts, $accounts_slice));
+        $crate::__process_n_accounts!(($($rest)*) => ($input, $accounts, $accounts_slice));
     };
 
     // Process one account.
@@ -320,44 +342,52 @@ macro_rules! process_n_accounts {
         $accounts = $accounts.add(1);
 
         // Read the next account.
-        let account: *mut RuntimeAccount = $input as *mut RuntimeAccount;
+        let account =$input as *mut $crate::account::RuntimeAccount;
         // Adds an 8-bytes offset for:
         //   - rent epoch in case of a non-duplicated account
         //   - duplicated marker + 7 bytes of padding in case of a duplicated account
         $input = $input.add(size_of::<u64>());
 
-        if (*account).borrow_state != NON_DUP_MARKER {
-            clone_account_view($accounts, $accounts_slice, (*account).borrow_state);
+        if (*account).borrow_state != $crate::entrypoint::NON_DUP_MARKER {
+            $crate::entrypoint::clone_account_view($accounts, $accounts_slice, (*account).borrow_state);
         } else {
-            #[cfg(feature = "account-resize")]
-            {
-                // Stores the data length in the `padding` field. This is needed
-                // to handle account resizing.
-                (*account).padding = u32::to_le_bytes((*account).data_len as u32);
-            }
-            $accounts.write(AccountView::new_unchecked(account));
-            advance_input_with_account!($input, account);
+            $crate::__store_data_length_in_padding!(account);
+            $accounts.write($crate::AccountView::new_unchecked(account));
+            $crate::__advance_input_with_account!($input, account);
         }
     };
 }
 
 /// Convenience macro to transform the number of accounts to process into a
-/// pattern of `_` tokens for the [`process_n_accounts`] macro.
-macro_rules! process_accounts {
+/// pattern of `_` tokens for the [`__process_n_accounts`] macro.
+#[macro_export]
+macro_rules! __process_accounts {
     ( 1 => ( $input:ident, $accounts:ident, $accounts_slice:ident ) ) => {
-        process_n_accounts!( (_) => ( $input, $accounts, $accounts_slice ));
+        $crate::__process_n_accounts!( (_) => ( $input, $accounts, $accounts_slice ));
     };
     ( 2 => ( $input:ident, $accounts:ident, $accounts_slice:ident ) ) => {
-        process_n_accounts!( (_ _) => ( $input, $accounts, $accounts_slice ));
+        $crate::__process_n_accounts!( (_ _) => ( $input, $accounts, $accounts_slice ));
     };
     ( 3 => ( $input:ident, $accounts:ident, $accounts_slice:ident ) ) => {
-        process_n_accounts!( (_ _ _) => ( $input, $accounts, $accounts_slice ));
+        $crate::__process_n_accounts!( (_ _ _) => ( $input, $accounts, $accounts_slice ));
     };
     ( 4 => ( $input:ident, $accounts:ident, $accounts_slice:ident ) ) => {
-        process_n_accounts!( (_ _ _ _) => ( $input, $accounts, $accounts_slice ));
+        $crate::__process_n_accounts!( (_ _ _ _) => ( $input, $accounts, $accounts_slice ));
     };
     ( 5 => ( $input:ident, $accounts:ident, $accounts_slice:ident ) ) => {
-        process_n_accounts!( (_ _ _ _ _) => ( $input, $accounts, $accounts_slice ));
+        $crate::__process_n_accounts!( (_ _ _ _ _) => ( $input, $accounts, $accounts_slice ));
+    };
+    ( 6 => ( $input:ident, $accounts:ident, $accounts_slice:ident ) ) => {
+        $crate::__process_n_accounts!( (_ _ _ _ _ _) => ( $input, $accounts, $accounts_slice ));
+    };
+    ( 7 => ( $input:ident, $accounts:ident, $accounts_slice:ident ) ) => {
+        $crate::__process_n_accounts!( (_ _ _ _ _ _ _) => ( $input, $accounts, $accounts_slice ));
+    };
+    ( 8 => ( $input:ident, $accounts:ident, $accounts_slice:ident ) ) => {
+        $crate::__process_n_accounts!( (_ _ _ _ _ _ _ _) => ( $input, $accounts, $accounts_slice ));
+    };
+    ( 9 => ( $input:ident, $accounts:ident, $accounts_slice:ident ) ) => {
+        $crate::__process_n_accounts!( (_ _ _ _ _ _ _ _ _) => ( $input, $accounts, $accounts_slice ));
     };
 }
 
@@ -378,7 +408,7 @@ macro_rules! process_accounts {
 #[allow(clippy::clone_on_copy)]
 #[cold]
 #[inline(always)]
-unsafe fn clone_account_view(
+pub unsafe fn clone_account_view(
     accounts: *mut AccountView,
     accounts_slice: *const AccountView,
     index: u8,
@@ -427,16 +457,11 @@ pub unsafe fn deserialize<const MAX_ACCOUNTS: usize>(
         // The first account is always non-duplicated, so process
         // it directly as such.
         let account: *mut RuntimeAccount = input as *mut RuntimeAccount;
-        #[cfg(feature = "account-resize")]
-        {
-            // Stores the data length in the `padding` field. This is needed
-            // to handle account resizing.
-            (*account).padding = u32::to_le_bytes((*account).data_len as u32);
-        }
+        __store_data_length_in_padding!(account);
         accounts.write(AccountView::new_unchecked(account));
 
         input = input.add(size_of::<u64>());
-        advance_input_with_account!(input, account);
+        __advance_input_with_account!(input, account);
 
         if processed > 1 {
             // The number of accounts to process (`to_process_plus_one`) is limited to
@@ -460,30 +485,30 @@ pub unsafe fn deserialize<const MAX_ACCOUNTS: usize>(
             processed = to_process_plus_one;
 
             // This is an optimization to reduce the number of jumps required to process the
-            // accounts. The macro `process_accounts` will generate inline code to process
+            // accounts. The macro `__process_accounts` will generate inline code to process
             // the specified number of accounts.
             if to_process_plus_one == 2 {
-                process_accounts!(1 => (input, accounts, accounts_slice));
+                __process_accounts!(1 => (input, accounts, accounts_slice));
             } else {
                 while to_process_plus_one > 5 {
                     // Process 5 accounts at a time.
-                    process_accounts!(5 => (input, accounts, accounts_slice));
+                    __process_accounts!(5 => (input, accounts, accounts_slice));
                     to_process_plus_one -= 5;
                 }
 
                 // There might be remaining accounts to process.
                 match to_process_plus_one {
                     5 => {
-                        process_accounts!(4 => (input, accounts, accounts_slice));
+                        __process_accounts!(4 => (input, accounts, accounts_slice));
                     }
                     4 => {
-                        process_accounts!(3 => (input, accounts, accounts_slice));
+                        __process_accounts!(3 => (input, accounts, accounts_slice));
                     }
                     3 => {
-                        process_accounts!(2 => (input, accounts, accounts_slice));
+                        __process_accounts!(2 => (input, accounts, accounts_slice));
                     }
                     2 => {
-                        process_accounts!(1 => (input, accounts, accounts_slice));
+                        __process_accounts!(1 => (input, accounts, accounts_slice));
                     }
                     1 => (),
                     _ => {
@@ -514,7 +539,7 @@ pub unsafe fn deserialize<const MAX_ACCOUNTS: usize>(
                     input = input.add(size_of::<u64>());
 
                     if (*account).borrow_state == NON_DUP_MARKER {
-                        advance_input_with_account!(input, account);
+                        __advance_input_with_account!(input, account);
                     }
                 }
             }
@@ -838,6 +863,7 @@ mod alloc {
 mod tests {
     use {
         super::*,
+        crate::BPF_ALIGN_OF_U128,
         ::alloc::{
             alloc::{alloc, dealloc, handle_alloc_error},
             vec,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -364,7 +364,7 @@ pub const MAX_TX_ACCOUNTS: usize = u8::MAX as usize;
 
 /// `assert_eq(core::mem::align_of::<u128>(), 8)` is true for BPF but not
 /// for some host machines.
-const BPF_ALIGN_OF_U128: usize = 8;
+pub const BPF_ALIGN_OF_U128: usize = 8;
 
 /// Return value for a successful program execution.
 pub const SUCCESS: u64 = 0;


### PR DESCRIPTION
### Problem

With the change proposed in SIMD-0321, the runtime will pass a pointer to the instruction data. This will allow programs to determine what instruction to execute before parsing the account data. Entrypoints can take advantage of this information to offer custom parsing logic, which is optimized by the number of accounts required by an instruction.

### Solution

Add a new entrypoint that makes use of the instruction data pointer. The rationale is that a program will inspect the instruction data to determine how many accounts and instruction to execute.

The `inline_program_entrypoint` macro is used to declare the entrypoint. The
only argument is the name of a function with this type signature:
```rust
fn process_instruction(input: ProgramInput) -> ProgramResult;
```
The `execute` macro takes three arguments: the number of accounts to parse from the input buffer, the program input, and the name of the processor function. The processor function has this type signature:
```rust
fn processor(
    program_id: &Address,
    accounts: &mut [AccountView],
    instruction_data: &[u8]
) -> ProgramResult;
```

#### Example

The example below consumes `30` CUs less than a similar program using the "standard" entrypoint.

```rust
use {
    pinocchio::{
        entrypoint::inline::ProgramInput, error::ProgramError, execute, inline_program_entrypoint,
        AccountView, Address, ProgramResult,
    },
    pinocchio_system::instructions::CreateAccount,
};

// Declares the entrypoint of the program.
inline_program_entrypoint!(process_instruction);

pub fn process_instruction(input: ProgramInput) -> ProgramResult {
    match input.data.first() {
        Some(&0) => execute!((3, input) => create),
        _ => Err(ProgramError::InvalidInstructionData),
    }
}

/// Instruction processor.
pub fn create(
    program_id: &Address,
    accounts: &mut [AccountView],
    _instruction_data: &[u8],
) -> ProgramResult {
    let [from, to, _system_program] = accounts else {
        return Err(ProgramError::NotEnoughAccountKeys);
    };

    CreateAccount {
        from,
        to,
        lamports: 1_000_000_000,
        space: 10,
        owner: program_id,
    }
    .invoke()
}
```