### PR TITLE
refactor(sdk): remove old rent exemption threshold

### DIFF
--- a/sdk/src/sysvars/rent.rs
+++ b/sdk/src/sysvars/rent.rs
@@ -87,7 +87,7 @@ impl Rent {
 
     /// Return a `Rent` from the given bytes.
     ///
-    /// This method performs a length and alignment validation. The caller must
+    /// This method performs a length validation. The caller must
     /// ensure that `bytes` contains a valid representation of `Rent`.
     #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProgramError> {


### PR DESCRIPTION
# Description 
This PR remove the old rent exempt constants and logics in favor of [SIMD-0194](https://github.com/solana-foundation/solana-improvement-documents/pull/194) been live in mainnet 