### PR TITLE
sdk: Enable default features

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -22,11 +22,12 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [features]
+account-resize = []
 alloc = ["solana-instruction-view?/slice-cpi"]
 copy = ["solana-account-view/copy", "solana-address/copy"]
 cpi = ["dep:solana-instruction-view"]
-default = ["alloc"]
-account-resize = []
+default = ["alloc", "copy", "sha2"]
+sha2 = ["solana-address/sha2"]
 unsafe-account-resize = []
 
 [dependencies]


### PR DESCRIPTION
### Problem

Currently to use additional features from re-exported crates (e.g., solana-address), it is necessary to separately import the crate. There are features that are used by most programs, which could be beneficial to enable them by default.

### Solution

This PR adds a `"sha2"` feature to enable `"solana-address/sha2"`, and adds both `"copy"` and `"sha2"` to the default features of pinocchio. Program can opt0out by disabling default features.