### PR TITLE
programs/system: Use invoke unchecked

### DIFF
--- a/programs/system/src/instructions/advance_nonce_account.rs
+++ b/programs/system/src/instructions/advance_nonce_account.rs
@@ -1,7 +1,11 @@
-use pinocchio::{
-    cpi::{invoke_signed, Signer},
-    instruction::{InstructionAccount, InstructionView},
-    AccountView, ProgramResult,
+use {
+    core::{mem::MaybeUninit, slice::from_raw_parts},
+    pinocchio::{
+        cpi::{invoke_signed_unchecked, CpiAccount, Signer},
+        error::ProgramError,
+        instruction::{InstructionAccount, InstructionView},
+        AccountView, ProgramResult,
+    },
 };
 
 /// Consumes a stored nonce, replacing it with a successor.
@@ -10,18 +14,21 @@ use pinocchio::{
 ///   0. `[WRITE]` Nonce account
 ///   1. `[]` Recent blockhashes sysvar
 ///   2. `[SIGNER]` Nonce authority
-pub struct AdvanceNonceAccount<'a> {
+pub struct AdvanceNonceAccount<'account> {
     /// Nonce account.
-    pub account: &'a AccountView,
+    pub account: &'account AccountView,
 
     /// Recent blockhashes sysvar.
-    pub recent_blockhashes_sysvar: &'a AccountView,
+    pub recent_blockhashes_sysvar: &'account AccountView,
 
     /// Nonce authority.
-    pub authority: &'a AccountView,
+    pub authority: &'account AccountView,
 }
 
 impl AdvanceNonceAccount<'_> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 4;
+
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_signed(&[])
@@ -29,24 +36,42 @@ impl AdvanceNonceAccount<'_> {
 
     #[inline(always)]
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 3] = [
-            InstructionAccount::writable(self.account.address()),
-            InstructionAccount::readonly(self.recent_blockhashes_sysvar.address()),
-            InstructionAccount::readonly_signer(self.authority.address()),
-        ];
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 3];
+        instruction_accounts[0].write(InstructionAccount::writable(self.account.address()));
+        instruction_accounts[1].write(InstructionAccount::readonly(
+            self.recent_blockhashes_sysvar.address(),
+        ));
+        instruction_accounts[2].write(InstructionAccount::readonly_signer(
+            self.authority.address(),
+        ));
 
         // instruction
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            data: &[4, 0, 0, 0],
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 3) },
+            data: &Self::DISCRIMINATOR.to_le_bytes(),
         };
 
-        invoke_signed(
-            &instruction,
-            &[self.account, self.recent_blockhashes_sysvar, self.authority],
-            signers,
-        )
+        if self.account.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 3];
+        CpiAccount::init_from_account_view(self.account, &mut accounts[0]);
+        CpiAccount::init_from_account_view(self.recent_blockhashes_sysvar, &mut accounts[1]);
+        CpiAccount::init_from_account_view(self.authority, &mut accounts[2]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(
+                &instruction,
+                from_raw_parts(accounts.as_ptr() as _, 3),
+                signers,
+            )
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/allocate.rs
+++ b/programs/system/src/instructions/allocate.rs
@@ -1,22 +1,29 @@
-use pinocchio::{
-    cpi::{invoke_signed, Signer},
-    instruction::{InstructionAccount, InstructionView},
-    AccountView, ProgramResult,
+use {
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
+    pinocchio::{
+        cpi::{invoke_signed_unchecked, CpiAccount, Signer},
+        error::ProgramError,
+        instruction::{InstructionAccount, InstructionView},
+        AccountView, ProgramResult,
+    },
 };
 
 /// Allocate space in a (possibly new) account without funding.
 ///
 /// ### Accounts:
 ///   0. `[WRITE, SIGNER]` New account
-pub struct Allocate<'a> {
+pub struct Allocate<'account> {
     /// Account to be assigned.
-    pub account: &'a AccountView,
+    pub account: &'account AccountView,
 
     /// Number of bytes of memory to allocate.
     pub space: u64,
 }
 
 impl Allocate<'_> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 8;
+
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_signed(&[])
@@ -24,23 +31,55 @@ impl Allocate<'_> {
 
     #[inline(always)]
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 1] =
-            [InstructionAccount::writable_signer(self.account.address())];
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 1];
+        instruction_accounts[0].write(InstructionAccount::writable_signer(self.account.address()));
 
         // instruction data
         // - [0..4 ]: instruction discriminator
         // - [4..12]: space
-        let mut instruction_data = [0; 12];
-        instruction_data[0] = 8;
-        instruction_data[4..12].copy_from_slice(&self.space.to_le_bytes());
+        let mut instruction_data = [const { MaybeUninit::<u8>::uninit() }; 12];
+        // SAFETY: All writes are within bounds of the allocated data.
+        unsafe {
+            let dst = instruction_data.as_mut_ptr() as *mut u8;
+
+            copy_nonoverlapping(
+                Self::DISCRIMINATOR.to_le_bytes().as_ptr(),
+                dst,
+                size_of::<u32>(),
+            );
+
+            copy_nonoverlapping(
+                self.space.to_le_bytes().as_ptr(),
+                dst.add(4),
+                size_of::<u64>(),
+            );
+        }
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            data: &instruction_data,
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 1) },
+            // SAFETY: `instruction_data` was initialized.
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 12) },
         };
 
-        invoke_signed(&instruction, &[self.account], signers)
+        if self.account.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 1];
+        CpiAccount::init_from_account_view(self.account, &mut accounts[0]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(
+                &instruction,
+                from_raw_parts(accounts.as_ptr() as _, 1),
+                signers,
+            )
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/allocate_with_seed.rs
+++ b/programs/system/src/instructions/allocate_with_seed.rs
@@ -1,13 +1,13 @@
 use {
-    crate::instructions::{write_bytes, UNINIT_BYTE},
-    core::slice::from_raw_parts,
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
     pinocchio::{
         address::MAX_SEED_LEN,
-        cpi::{invoke_signed, Signer},
+        cpi::{invoke_signed_unchecked, CpiAccount, Signer},
         error::ProgramError,
         instruction::{InstructionAccount, InstructionView},
         AccountView, Address, ProgramResult,
     },
+    solana_address::ADDRESS_BYTES,
 };
 
 /// Allocate space for and assign an account at an address derived
@@ -16,28 +16,31 @@ use {
 /// ### Accounts:
 ///   0. `[WRITE]` Allocated account
 ///   1. `[SIGNER]` Base account
-pub struct AllocateWithSeed<'a, 'b, 'c> {
+pub struct AllocateWithSeed<'account, 'address, 'seed> {
     /// Allocated account.
-    pub account: &'a AccountView,
+    pub account: &'account AccountView,
 
     /// Base account.
     ///
     /// The account matching the base address below must be provided as
     /// a signer, but may be the same as the funding account and provided
     /// as account 0.
-    pub base: &'a AccountView,
+    pub base: &'account AccountView,
 
     /// String of ASCII chars, no longer than [`MAX_SEED_LEN`](https://docs.rs/solana-address/latest/solana_address/constant.MAX_SEED_LEN.html).
-    pub seed: &'b str,
+    pub seed: &'seed str,
 
     /// Number of bytes of memory to allocate.
     pub space: u64,
 
     /// Address of program that will own the new account.
-    pub owner: &'c Address,
+    pub owner: &'address Address,
 }
 
 impl AllocateWithSeed<'_, '_, '_> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 9;
+
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_signed(&[])
@@ -45,13 +48,14 @@ impl AllocateWithSeed<'_, '_, '_> {
 
     #[inline(always)]
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 2] = [
-            InstructionAccount::writable(self.account.address()),
-            InstructionAccount::readonly_signer(self.base.address()),
-        ];
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 2];
+        instruction_accounts[0].write(InstructionAccount::writable(self.account.address()));
+        instruction_accounts[1].write(InstructionAccount::readonly_signer(self.base.address()));
 
-        if self.seed.len() > MAX_SEED_LEN {
+        let seed_bytes = self.seed.as_bytes();
+
+        if seed_bytes.len() > MAX_SEED_LEN {
             return Err(ProgramError::InvalidInstructionData);
         }
 
@@ -62,37 +66,69 @@ impl AllocateWithSeed<'_, '_, '_> {
         // - [44..  ]: seed (max 32)
         // - [..  +8]: account space
         // - [.. +32]: owner address
-        let mut instruction_data = [UNINIT_BYTE; 116];
+        let mut instruction_data = [const { MaybeUninit::<u8>::uninit() }; 116];
+        // SAFETY: All writes are within bounds of the allocated data.
+        unsafe {
+            let dst = instruction_data.as_mut_ptr() as *mut u8;
 
-        write_bytes(&mut instruction_data[..4], &[9, 0, 0, 0]);
+            copy_nonoverlapping(
+                Self::DISCRIMINATOR.to_le_bytes().as_ptr(),
+                dst,
+                size_of::<u32>(),
+            );
 
-        write_bytes(&mut instruction_data[4..36], self.base.address().as_array());
+            copy_nonoverlapping(
+                self.base.address().as_ref().as_ptr(),
+                dst.add(4),
+                ADDRESS_BYTES,
+            );
 
-        write_bytes(
-            &mut instruction_data[36..44],
-            &u64::to_le_bytes(self.seed.len() as u64),
-        );
+            copy_nonoverlapping(
+                u64::to_le_bytes(seed_bytes.len() as u64).as_ptr(),
+                dst.add(36),
+                size_of::<u64>(),
+            );
 
-        let offset = 44 + self.seed.len();
-        write_bytes(&mut instruction_data[44..offset], self.seed.as_bytes());
+            copy_nonoverlapping(seed_bytes.as_ptr(), dst.add(44), seed_bytes.len());
 
-        write_bytes(
-            &mut instruction_data[offset..offset + 8],
-            &self.space.to_le_bytes(),
-        );
+            copy_nonoverlapping(
+                self.space.to_le_bytes().as_ptr(),
+                dst.add(44 + seed_bytes.len()),
+                size_of::<u64>(),
+            );
 
-        write_bytes(
-            &mut instruction_data[offset + 8..offset + 40],
-            self.owner.as_ref(),
-        );
+            copy_nonoverlapping(
+                self.owner.as_ref().as_ptr(),
+                dst.add(52 + seed_bytes.len()),
+                ADDRESS_BYTES,
+            );
+        }
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            // SAFETY: The instruction data is initialized.
-            data: unsafe { from_raw_parts(instruction_data.as_ptr() as *const _, offset + 40) },
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 2) },
+            // SAFETY: `instruction_data` was initialized.
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 84 + seed_bytes.len()) },
         };
 
-        invoke_signed(&instruction, &[self.account, self.base], signers)
+        if self.account.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 2];
+        CpiAccount::init_from_account_view(self.account, &mut accounts[0]);
+        CpiAccount::init_from_account_view(self.base, &mut accounts[1]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(
+                &instruction,
+                from_raw_parts(accounts.as_ptr() as _, 2),
+                signers,
+            )
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/assign.rs
+++ b/programs/system/src/instructions/assign.rs
@@ -1,22 +1,30 @@
-use pinocchio::{
-    cpi::{invoke_signed, Signer},
-    instruction::{InstructionAccount, InstructionView},
-    AccountView, Address, ProgramResult,
+use {
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
+    pinocchio::{
+        cpi::{invoke_signed_unchecked, CpiAccount, Signer},
+        error::ProgramError,
+        instruction::{InstructionAccount, InstructionView},
+        AccountView, Address, ProgramResult,
+    },
+    solana_address::ADDRESS_BYTES,
 };
 
 /// Assign account to a program
 ///
 /// ### Accounts:
 ///   0. `[WRITE, SIGNER]` Assigned account address
-pub struct Assign<'a, 'b> {
+pub struct Assign<'account, 'address> {
     /// Account to be assigned.
-    pub account: &'a AccountView,
+    pub account: &'account AccountView,
 
     /// Program account to assign as owner.
-    pub owner: &'b Address,
+    pub owner: &'address Address,
 }
 
 impl Assign<'_, '_> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 1;
+
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_signed(&[])
@@ -24,23 +32,51 @@ impl Assign<'_, '_> {
 
     #[inline(always)]
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 1] =
-            [InstructionAccount::writable_signer(self.account.address())];
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 1];
+        instruction_accounts[0].write(InstructionAccount::writable_signer(self.account.address()));
 
         // instruction data
         // - [0..4 ]: instruction discriminator
         // - [4..36]: owner address
-        let mut instruction_data = [0; 36];
-        instruction_data[0] = 1;
-        instruction_data[4..36].copy_from_slice(self.owner.as_ref());
+        let mut instruction_data = [const { MaybeUninit::<u8>::uninit() }; 36];
+        // SAFETY: All writes are within bounds of the allocated data.
+        unsafe {
+            let dst = instruction_data.as_mut_ptr() as *mut u8;
+
+            copy_nonoverlapping(
+                Self::DISCRIMINATOR.to_le_bytes().as_ptr(),
+                dst,
+                size_of::<u32>(),
+            );
+
+            copy_nonoverlapping(self.owner.as_ref().as_ptr(), dst.add(4), ADDRESS_BYTES);
+        }
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            data: &instruction_data,
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 1) },
+            // SAFETY: `instruction_data` was initialized.
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 36) },
         };
 
-        invoke_signed(&instruction, &[self.account], signers)
+        if self.account.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 1];
+        CpiAccount::init_from_account_view(self.account, &mut accounts[0]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(
+                &instruction,
+                from_raw_parts(accounts.as_ptr() as _, 1),
+                signers,
+            )
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/assign_with_seed.rs
+++ b/programs/system/src/instructions/assign_with_seed.rs
@@ -1,13 +1,13 @@
 use {
-    crate::instructions::{write_bytes, UNINIT_BYTE},
-    core::slice::from_raw_parts,
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
     pinocchio::{
         address::MAX_SEED_LEN,
-        cpi::{invoke_signed, Signer},
+        cpi::{invoke_signed_unchecked, CpiAccount, Signer},
         error::ProgramError,
         instruction::{InstructionAccount, InstructionView},
         AccountView, Address, ProgramResult,
     },
+    solana_address::ADDRESS_BYTES,
 };
 
 /// Assign account to a program based on a seed.
@@ -15,25 +15,28 @@ use {
 /// ### Accounts:
 ///   0. `[WRITE]` Assigned account
 ///   1. `[SIGNER]` Base account
-pub struct AssignWithSeed<'a, 'b, 'c> {
+pub struct AssignWithSeed<'account, 'address, 'seed> {
     /// Allocated account.
-    pub account: &'a AccountView,
+    pub account: &'account AccountView,
 
     /// Base account.
     ///
     /// The account matching the base `Address` below must be provided as
     /// a signer, but may be the same as the funding account and provided
     /// as account 0.
-    pub base: &'a AccountView,
+    pub base: &'account AccountView,
 
     /// String of ASCII chars, no longer than [`MAX_SEED_LEN`](https://docs.rs/solana-address/latest/solana_address/constant.MAX_SEED_LEN.html).
-    pub seed: &'b str,
+    pub seed: &'seed str,
 
     /// Address of program that will own the new account.
-    pub owner: &'c Address,
+    pub owner: &'address Address,
 }
 
 impl AssignWithSeed<'_, '_, '_> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 10;
+
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_signed(&[])
@@ -41,13 +44,14 @@ impl AssignWithSeed<'_, '_, '_> {
 
     #[inline(always)]
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 2] = [
-            InstructionAccount::writable(self.account.address()),
-            InstructionAccount::readonly_signer(self.base.address()),
-        ];
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 2];
+        instruction_accounts[0].write(InstructionAccount::writable(self.account.address()));
+        instruction_accounts[1].write(InstructionAccount::readonly_signer(self.base.address()));
 
-        if self.seed.len() > MAX_SEED_LEN {
+        let seed_bytes = self.seed.as_bytes();
+
+        if seed_bytes.len() > MAX_SEED_LEN {
             return Err(ProgramError::InvalidInstructionData);
         }
 
@@ -57,39 +61,63 @@ impl AssignWithSeed<'_, '_, '_> {
         // - [36..44]: seed length
         // - [44..  ]: seed (max 32)
         // - [.. +32]: owner address
-        let mut instruction_data = [UNINIT_BYTE; 108];
+        let mut instruction_data = [const { MaybeUninit::<u8>::uninit() }; 108];
+        // SAFETY: All writes are within bounds of the allocated data.
+        unsafe {
+            let dst = instruction_data.as_mut_ptr() as *mut u8;
 
-        write_bytes(&mut instruction_data[..4], &[10, 0, 0, 0]);
+            copy_nonoverlapping(
+                Self::DISCRIMINATOR.to_le_bytes().as_ptr(),
+                dst,
+                size_of::<u32>(),
+            );
 
-        write_bytes(&mut instruction_data[4..36], self.base.address().as_array());
+            copy_nonoverlapping(
+                self.base.address().as_ref().as_ptr(),
+                dst.add(4),
+                ADDRESS_BYTES,
+            );
 
-        write_bytes(
-            &mut instruction_data[36..44],
-            &u64::to_le_bytes(self.seed.len() as u64),
-        );
+            copy_nonoverlapping(
+                u64::to_le_bytes(seed_bytes.len() as u64).as_ptr(),
+                dst.add(36),
+                size_of::<u64>(),
+            );
 
-        let offset = 44 + self.seed.len();
-        write_bytes(
-            // SAFETY: instruction data allocated `MAX_SEED_LEN` bytes for
-            // the seed.
-            unsafe { instruction_data.get_unchecked_mut(44..offset) },
-            self.seed.as_bytes(),
-        );
+            copy_nonoverlapping(seed_bytes.as_ptr(), dst.add(44), seed_bytes.len());
 
-        write_bytes(
-            // SAFETY: instruction data allocated space for the owner address
-            // after the seed.
-            unsafe { instruction_data.get_unchecked_mut(offset..offset + 32) },
-            self.owner.as_ref(),
-        );
+            copy_nonoverlapping(
+                self.owner.as_ref().as_ptr(),
+                dst.add(44 + seed_bytes.len()),
+                ADDRESS_BYTES,
+            );
+        }
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            // SAFETY: The instruction data is initialized.
-            data: unsafe { from_raw_parts(instruction_data.as_ptr() as *const _, offset + 32) },
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 2) },
+            // SAFETY: `instruction_data` was initialized.
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 76 + seed_bytes.len()) },
         };
 
-        invoke_signed(&instruction, &[self.account, self.base], signers)
+        if self.account.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 2];
+        CpiAccount::init_from_account_view(self.account, &mut accounts[0]);
+        CpiAccount::init_from_account_view(self.base, &mut accounts[1]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(
+                &instruction,
+                from_raw_parts(accounts.as_ptr() as _, 2),
+                signers,
+            )
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/authorize_nonce_account.rs
+++ b/programs/system/src/instructions/authorize_nonce_account.rs
@@ -1,7 +1,12 @@
-use pinocchio::{
-    cpi::{invoke_signed, Signer},
-    instruction::{InstructionAccount, InstructionView},
-    AccountView, Address, ProgramResult,
+use {
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
+    pinocchio::{
+        cpi::{invoke_signed_unchecked, CpiAccount, Signer},
+        error::ProgramError,
+        instruction::{InstructionAccount, InstructionView},
+        AccountView, Address, ProgramResult,
+    },
+    solana_address::ADDRESS_BYTES,
 };
 
 /// Change the entity authorized to execute nonce instructions on the account.
@@ -11,18 +16,21 @@ use pinocchio::{
 /// ### Accounts:
 ///   0. `[WRITE]` Nonce account
 ///   1. `[SIGNER]` Nonce authority
-pub struct AuthorizeNonceAccount<'a, 'b> {
+pub struct AuthorizeNonceAccount<'account, 'address> {
     /// Nonce account.
-    pub account: &'a AccountView,
+    pub account: &'account AccountView,
 
     /// Nonce authority.
-    pub authority: &'a AccountView,
+    pub authority: &'account AccountView,
 
     /// New entity authorized to execute nonce instructions on the account.
-    pub new_authority: &'b Address,
+    pub new_authority: &'address Address,
 }
 
 impl AuthorizeNonceAccount<'_, '_> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 7;
+
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_signed(&[])
@@ -30,25 +38,58 @@ impl AuthorizeNonceAccount<'_, '_> {
 
     #[inline(always)]
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 2] = [
-            InstructionAccount::writable(self.account.address()),
-            InstructionAccount::readonly_signer(self.authority.address()),
-        ];
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 2];
+        instruction_accounts[0].write(InstructionAccount::writable(self.account.address()));
+        instruction_accounts[1].write(InstructionAccount::readonly_signer(
+            self.authority.address(),
+        ));
 
         // instruction data
         // - [0..4 ]: instruction discriminator
         // - [4..12]: lamports
-        let mut instruction_data = [0; 36];
-        instruction_data[0] = 7;
-        instruction_data[4..36].copy_from_slice(self.new_authority.as_array());
+        let mut instruction_data = [const { MaybeUninit::<u8>::uninit() }; 36];
+        // SAFETY: All writes are within bounds of the allocated data.
+        unsafe {
+            let dst = instruction_data.as_mut_ptr() as *mut u8;
+
+            copy_nonoverlapping(
+                Self::DISCRIMINATOR.to_le_bytes().as_ptr(),
+                dst,
+                size_of::<u32>(),
+            );
+
+            copy_nonoverlapping(
+                self.new_authority.as_ref().as_ptr(),
+                dst.add(4),
+                ADDRESS_BYTES,
+            );
+        }
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            data: &instruction_data,
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 2) },
+            // SAFETY: `instruction_data` was initialized.
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 36) },
         };
 
-        invoke_signed(&instruction, &[self.account, self.authority], signers)
+        if self.account.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 2];
+        CpiAccount::init_from_account_view(self.account, &mut accounts[0]);
+        CpiAccount::init_from_account_view(self.authority, &mut accounts[1]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(
+                &instruction,
+                from_raw_parts(accounts.as_ptr() as _, 2),
+                signers,
+            )
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/create_account.rs
+++ b/programs/system/src/instructions/create_account.rs
@@ -1,9 +1,13 @@
-use pinocchio::{
-    cpi::{invoke_signed, Signer},
-    error::ProgramError,
-    instruction::{InstructionAccount, InstructionView},
-    sysvars::{rent::Rent, Sysvar},
-    AccountView, Address, ProgramResult,
+use {
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
+    pinocchio::{
+        cpi::{invoke_signed_unchecked, CpiAccount, Signer},
+        error::ProgramError,
+        instruction::{InstructionAccount, InstructionView},
+        sysvars::{rent::Rent, Sysvar},
+        AccountView, Address, ProgramResult,
+    },
+    solana_address::ADDRESS_BYTES,
 };
 
 /// Create a new account.
@@ -11,12 +15,12 @@ use pinocchio::{
 /// ### Accounts:
 ///   0. `[WRITE, SIGNER]` Funding account
 ///   1. `[WRITE, SIGNER]` New account
-pub struct CreateAccount<'a, 'b> {
+pub struct CreateAccount<'account, 'address> {
     /// Funding account.
-    pub from: &'a AccountView,
+    pub from: &'account AccountView,
 
     /// New account.
-    pub to: &'a AccountView,
+    pub to: &'account AccountView,
 
     /// Number of lamports to transfer to the new account.
     pub lamports: u64,
@@ -25,29 +29,32 @@ pub struct CreateAccount<'a, 'b> {
     pub space: u64,
 
     /// Address of program that will own the new account.
-    pub owner: &'b Address,
+    pub owner: &'address Address,
 }
 
-impl<'a, 'b> CreateAccount<'a, 'b> {
+impl<'account, 'address> CreateAccount<'account, 'address> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 0;
+
     #[deprecated(since = "0.5.0", note = "Use `with_minimum_balance` instead")]
     #[inline(always)]
     pub fn with_minimal_balance(
-        from: &'a AccountView,
-        to: &'a AccountView,
-        rent_sysvar: &'a AccountView,
+        from: &'account AccountView,
+        to: &'account AccountView,
+        rent_sysvar: &'account AccountView,
         space: u64,
-        owner: &'b Address,
+        owner: &'address Address,
     ) -> Result<Self, ProgramError> {
         Self::with_minimum_balance(from, to, space, owner, Some(rent_sysvar))
     }
 
     #[inline(always)]
     pub fn with_minimum_balance(
-        from: &'a AccountView,
-        to: &'a AccountView,
+        from: &'account AccountView,
+        to: &'account AccountView,
         space: u64,
-        owner: &'b Address,
-        rent_sysvar: Option<&'a AccountView>,
+        owner: &'address Address,
+        rent_sysvar: Option<&'account AccountView>,
     ) -> Result<Self, ProgramError> {
         let lamports = if let Some(rent_sysvar) = rent_sysvar {
             let rent = Rent::from_account_view(rent_sysvar)?;
@@ -72,29 +79,67 @@ impl<'a, 'b> CreateAccount<'a, 'b> {
 
     #[inline(always)]
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 2] = [
-            InstructionAccount::writable_signer(self.from.address()),
-            InstructionAccount::writable_signer(self.to.address()),
-        ];
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 2];
+        instruction_accounts[0].write(InstructionAccount::writable_signer(self.from.address()));
+        instruction_accounts[1].write(InstructionAccount::writable_signer(self.to.address()));
 
-        // instruction data
+        // Instruction data:
         // - [0..4  ]: instruction discriminator
         // - [4..12 ]: lamports
         // - [12..20]: account space
         // - [20..52]: owner address
-        let mut instruction_data = [0; 52];
-        // create account instruction has a '0' discriminator
-        instruction_data[4..12].copy_from_slice(&self.lamports.to_le_bytes());
-        instruction_data[12..20].copy_from_slice(&self.space.to_le_bytes());
-        instruction_data[20..52].copy_from_slice(self.owner.as_ref());
+        let mut instruction_data = [const { MaybeUninit::<u8>::uninit() }; 52];
+        // SAFETY: All writes are within bounds of the allocated data.
+        unsafe {
+            let dst = instruction_data.as_mut_ptr() as *mut u8;
+
+            copy_nonoverlapping(
+                Self::DISCRIMINATOR.to_le_bytes().as_ptr(),
+                dst,
+                size_of::<u32>(),
+            );
+
+            copy_nonoverlapping(
+                self.lamports.to_le_bytes().as_ptr(),
+                dst.add(4),
+                size_of::<u64>(),
+            );
+
+            copy_nonoverlapping(
+                self.space.to_le_bytes().as_ptr(),
+                dst.add(12),
+                size_of::<u64>(),
+            );
+
+            copy_nonoverlapping(self.owner.as_ref().as_ptr(), dst.add(20), ADDRESS_BYTES);
+        }
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            data: &instruction_data,
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 2) },
+            // SAFETY: `instruction_data` was initialized.
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 52) },
         };
 
-        invoke_signed(&instruction, &[self.from, self.to], signers)
+        if self.from.is_borrowed() | self.to.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 2];
+        CpiAccount::init_from_account_view(self.from, &mut accounts[0]);
+        CpiAccount::init_from_account_view(self.to, &mut accounts[1]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(
+                &instruction,
+                from_raw_parts(accounts.as_ptr() as _, 2),
+                signers,
+            )
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/create_account_allow_prefund.rs
+++ b/programs/system/src/instructions/create_account_allow_prefund.rs
@@ -1,19 +1,19 @@
 use {
-    crate::instructions::{write_bytes, UNINIT_BYTE},
-    core::{mem::MaybeUninit, slice::from_raw_parts},
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
     pinocchio::{
-        cpi::{invoke_signed_with_bounds, Signer},
+        cpi::{invoke_signed_unchecked, CpiAccount, Signer},
         error::ProgramError,
         instruction::{InstructionAccount, InstructionView},
         sysvars::{rent::Rent, Sysvar},
         AccountView, Address, ProgramResult,
     },
+    solana_address::ADDRESS_BYTES,
 };
 
 /// Funding lamports to transfer into a newly created account.
-pub struct Funding<'a> {
+pub struct Funding<'account> {
     /// Funding account.
-    pub from: &'a AccountView,
+    pub from: &'account AccountView,
 
     /// Number of lamports to transfer to the new account.
     pub lamports: u64,
@@ -35,25 +35,28 @@ pub struct Funding<'a> {
 ///
 /// ### Accounts:
 ///   0. `[WRITE, SIGNER]` New account
-///   1. `[WRITE, SIGNER]` (OPTIONAL) Funding account
-pub struct CreateAccountAllowPrefund<'a, 'b> {
+///   1. `[WRITE, SIGNER]` (optional) Funding account
+pub struct CreateAccountAllowPrefund<'account, 'address> {
     /// New account.
-    pub to: &'a AccountView,
+    pub to: &'account AccountView,
 
     /// Number of bytes of memory to allocate.
     pub space: u64,
 
     /// Address of program that will own the new account.
-    pub owner: &'b Address,
+    pub owner: &'address Address,
 
     /// Funding for the new account.
     ///
     /// If `None`, the instruction will not transfer any
     /// lamports to the new account.
-    pub funding: Option<Funding<'a>>,
+    pub funding: Option<Funding<'account>>,
 }
 
-impl<'a, 'b> CreateAccountAllowPrefund<'a, 'b> {
+impl<'account, 'address> CreateAccountAllowPrefund<'account, 'address> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 13;
+
     /// Creates a new `CreateAccountAllowPrefund` instruction with the minimum
     /// balance required for the account.
     ///
@@ -61,11 +64,11 @@ impl<'a, 'b> CreateAccountAllowPrefund<'a, 'b> {
     /// no lamports will be transferred.
     #[inline(always)]
     pub fn with_minimum_balance(
-        from: &'a AccountView,
-        to: &'a AccountView,
+        from: &'account AccountView,
+        to: &'account AccountView,
         space: u64,
-        owner: &'b Address,
-        rent_sysvar: Option<&'a AccountView>,
+        owner: &'address Address,
+        rent_sysvar: Option<&'account AccountView>,
     ) -> Result<Self, ProgramError> {
         let required_lamports = if let Some(rent_sysvar) = rent_sysvar {
             Rent::from_account_view(rent_sysvar)?.try_minimum_balance(space as usize)?
@@ -94,61 +97,88 @@ impl<'a, 'b> CreateAccountAllowPrefund<'a, 'b> {
 
     #[inline(always)]
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 2];
+        instruction_accounts[0].write(InstructionAccount::writable_signer(self.to.address()));
+
         // instruction data
         // - [0..4  ]: instruction discriminator
         // - [4..12 ]: lamports
         // - [12..20]: account space
         // - [20..52]: owner address
-        let mut instruction_data = [UNINIT_BYTE; 52];
+        let mut instruction_data = [const { MaybeUninit::<u8>::uninit() }; 52];
+        // SAFETY: All writes are within bounds of the allocated data.
+        unsafe {
+            let dst = instruction_data.as_mut_ptr() as *mut u8;
 
-        write_bytes(&mut instruction_data[..4], &[13, 0, 0, 0]);
+            copy_nonoverlapping(
+                Self::DISCRIMINATOR.to_le_bytes().as_ptr(),
+                dst,
+                size_of::<u32>(),
+            );
 
-        write_bytes(&mut instruction_data[12..20], &self.space.to_le_bytes());
+            copy_nonoverlapping(
+                self.space.to_le_bytes().as_ptr(),
+                dst.add(12),
+                size_of::<u64>(),
+            );
 
-        write_bytes(&mut instruction_data[20..52], self.owner.as_ref());
+            copy_nonoverlapping(self.owner.as_ref().as_ptr(), dst.add(20), ADDRESS_BYTES);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 2];
+        CpiAccount::init_from_account_view(self.to, &mut accounts[0]);
 
         // Determine the accounts to pass to the instruction based on whether funding
         // is present or not.
-
-        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 2];
-
-        instruction_accounts[0].write(InstructionAccount::writable_signer(self.to.address()));
-
-        let mut accounts = [const { MaybeUninit::<&AccountView>::uninit() }; 2];
-
-        accounts[0].write(self.to);
-
         let expected_accounts = if let Some(funding) = &self.funding {
-            write_bytes(
-                &mut instruction_data[4..12],
-                &funding.lamports.to_le_bytes(),
-            );
+            if self.to.is_borrowed() | funding.from.is_borrowed() {
+                return Err(ProgramError::AccountBorrowFailed);
+            }
+
+            // SAFETY: The copy is within bounds of the allocated data.
+            unsafe {
+                let dst = instruction_data.as_mut_ptr() as *mut u8;
+
+                copy_nonoverlapping(
+                    funding.lamports.to_le_bytes().as_ptr(),
+                    dst.add(4),
+                    size_of::<u64>(),
+                );
+            }
 
             instruction_accounts[1]
                 .write(InstructionAccount::writable_signer(funding.from.address()));
-
-            accounts[1].write(funding.from);
+            CpiAccount::init_from_account_view(funding.from, &mut accounts[1]);
 
             2
         } else {
-            write_bytes(&mut instruction_data[4..12], &[0; 8]);
+            if self.to.is_borrowed() {
+                return Err(ProgramError::AccountBorrowFailed);
+            }
+
+            // SAFETY: The copy is within bounds of the allocated data.
+            unsafe {
+                let dst = instruction_data.as_mut_ptr() as *mut u8;
+                copy_nonoverlapping(0u64.to_le_bytes().as_ptr(), dst.add(4), size_of::<u64>());
+            }
 
             1
         };
 
-        invoke_signed_with_bounds::<2, _>(
-            &InstructionView {
-                program_id: &crate::ID,
-                // SAFETY: instruction accounts has `expected_accounts` initialized.
-                accounts: unsafe {
-                    from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts)
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(
+                &InstructionView {
+                    program_id: &crate::ID,
+                    accounts: from_raw_parts(instruction_accounts.as_ptr() as _, expected_accounts),
+                    data: from_raw_parts(instruction_data.as_ptr() as _, 52),
                 },
-                // SAFETY: instruction data is initialized.
-                data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 52) },
-            },
-            // SAFETY: accounts has `expected_accounts` initialized.
-            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, expected_accounts) },
-            signers,
-        )
+                from_raw_parts(accounts.as_ptr() as _, expected_accounts),
+                signers,
+            )
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/create_account_with_seed.rs
+++ b/programs/system/src/instructions/create_account_with_seed.rs
@@ -1,14 +1,14 @@
 use {
-    crate::instructions::{write_bytes, UNINIT_BYTE},
-    core::slice::from_raw_parts,
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
     pinocchio::{
         address::MAX_SEED_LEN,
-        cpi::{invoke_signed, Signer},
+        cpi::{invoke_signed_unchecked, CpiAccount, Signer},
         error::ProgramError,
         instruction::{InstructionAccount, InstructionView},
         sysvars::{rent::Rent, Sysvar},
         AccountView, Address, ProgramResult,
     },
+    solana_address::ADDRESS_BYTES,
 };
 
 /// Create a new account at an address derived from a base address and a seed.
@@ -19,22 +19,22 @@ use {
 ///   2. `[SIGNER]` (optional) Base account; the account matching the base
 ///      address below must be provided as a signer, but may be the same as the
 ///      funding account
-pub struct CreateAccountWithSeed<'a, 'b, 'c> {
+pub struct CreateAccountWithSeed<'account, 'address, 'seed> {
     /// Funding account.
-    pub from: &'a AccountView,
+    pub from: &'account AccountView,
 
     /// New account.
-    pub to: &'a AccountView,
+    pub to: &'account AccountView,
 
     /// Base account.
     ///
     /// The account matching the base [`Address`] below must be provided as
     /// a signer, but may be the same as the funding account and provided
     /// as account 0.
-    pub base: Option<&'a AccountView>,
+    pub base: Option<&'account AccountView>,
 
     /// String of ASCII chars, no longer than [`MAX_SEED_LEN`](https://docs.rs/solana-address/latest/solana_address/constant.MAX_SEED_LEN.html).
-    pub seed: &'b str,
+    pub seed: &'seed str,
 
     /// Number of lamports to transfer to the new account.
     pub lamports: u64,
@@ -43,33 +43,36 @@ pub struct CreateAccountWithSeed<'a, 'b, 'c> {
     pub space: u64,
 
     /// Address of program that will own the new account.
-    pub owner: &'c Address,
+    pub owner: &'address Address,
 }
 
-impl<'a, 'b, 'c> CreateAccountWithSeed<'a, 'b, 'c> {
+impl<'account, 'address, 'seed> CreateAccountWithSeed<'account, 'address, 'seed> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 3;
+
     #[deprecated(since = "0.5.0", note = "Use `with_minimum_balance` instead")]
     #[inline(always)]
     pub fn with_minimal_balance(
-        from: &'a AccountView,
-        to: &'a AccountView,
-        base: Option<&'a AccountView>,
-        seed: &'b str,
-        rent_sysvar: &'a AccountView,
+        from: &'account AccountView,
+        to: &'account AccountView,
+        base: Option<&'account AccountView>,
+        seed: &'seed str,
+        rent_sysvar: &'account AccountView,
         space: u64,
-        owner: &'c Address,
+        owner: &'address Address,
     ) -> Result<Self, ProgramError> {
         Self::with_minimum_balance(from, to, base, seed, space, owner, Some(rent_sysvar))
     }
 
     #[inline(always)]
     pub fn with_minimum_balance(
-        from: &'a AccountView,
-        to: &'a AccountView,
-        base: Option<&'a AccountView>,
-        seed: &'b str,
+        from: &'account AccountView,
+        to: &'account AccountView,
+        base: Option<&'account AccountView>,
+        seed: &'seed str,
         space: u64,
-        owner: &'c Address,
-        rent_sysvar: Option<&'a AccountView>,
+        owner: &'address Address,
+        rent_sysvar: Option<&'account AccountView>,
     ) -> Result<Self, ProgramError> {
         let lamports = if let Some(rent_sysvar) = rent_sysvar {
             let rent = Rent::from_account_view(rent_sysvar)?;
@@ -96,14 +99,17 @@ impl<'a, 'b, 'c> CreateAccountWithSeed<'a, 'b, 'c> {
 
     #[inline(always)]
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 3] = [
-            InstructionAccount::writable_signer(self.from.address()),
-            InstructionAccount::writable(self.to.address()),
-            InstructionAccount::readonly_signer(self.base.unwrap_or(self.from).address()),
-        ];
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 3];
+        instruction_accounts[0].write(InstructionAccount::writable_signer(self.from.address()));
+        instruction_accounts[1].write(InstructionAccount::writable(self.to.address()));
+        instruction_accounts[2].write(InstructionAccount::readonly_signer(
+            self.base.unwrap_or(self.from).address(),
+        ));
 
-        if self.seed.len() > MAX_SEED_LEN {
+        let seed_bytes = self.seed.as_bytes();
+
+        if seed_bytes.len() > MAX_SEED_LEN {
             return Err(ProgramError::InvalidInstructionData);
         }
 
@@ -115,57 +121,76 @@ impl<'a, 'b, 'c> CreateAccountWithSeed<'a, 'b, 'c> {
         // - [..  +8]: lamports
         // - [..  +8]: account space
         // - [.. +32]: owner address
-        let mut instruction_data = [UNINIT_BYTE; 124];
+        let mut instruction_data = [const { MaybeUninit::<u8>::uninit() }; 124];
+        // SAFETY: All writes are within bounds of the allocated data.
+        unsafe {
+            let dst = instruction_data.as_mut_ptr() as *mut u8;
 
-        write_bytes(&mut instruction_data[..4], &[3, 0, 0, 0]);
+            copy_nonoverlapping(
+                Self::DISCRIMINATOR.to_le_bytes().as_ptr(),
+                dst,
+                size_of::<u32>(),
+            );
 
-        write_bytes(
-            &mut instruction_data[4..36],
-            self.base.unwrap_or(self.from).address().as_array(),
-        );
+            copy_nonoverlapping(
+                self.base.unwrap_or(self.from).address().as_ref().as_ptr(),
+                dst.add(4),
+                ADDRESS_BYTES,
+            );
 
-        write_bytes(
-            &mut instruction_data[36..44],
-            &u64::to_le_bytes(self.seed.len() as u64),
-        );
+            copy_nonoverlapping(
+                u64::to_le_bytes(seed_bytes.len() as u64).as_ptr(),
+                dst.add(36),
+                size_of::<u64>(),
+            );
 
-        let offset = 44 + self.seed.len();
-        write_bytes(
-            // SAFETY: instruction data allocated `MAX_SEED_LEN` bytes
-            // for the seed.
-            unsafe { instruction_data.get_unchecked_mut(44..offset) },
-            self.seed.as_bytes(),
-        );
+            copy_nonoverlapping(seed_bytes.as_ptr(), dst.add(44), seed_bytes.len());
 
-        write_bytes(
-            // SAFETY: instruction data allocated space for the lamports.
-            unsafe { instruction_data.get_unchecked_mut(offset..offset + 8) },
-            &self.lamports.to_le_bytes(),
-        );
+            copy_nonoverlapping(
+                self.lamports.to_le_bytes().as_ptr(),
+                dst.add(44 + seed_bytes.len()),
+                size_of::<u64>(),
+            );
 
-        write_bytes(
-            // SAFETY: instruction data allocated space for the `space`.
-            unsafe { instruction_data.get_unchecked_mut(offset + 8..offset + 16) },
-            &self.space.to_le_bytes(),
-        );
+            copy_nonoverlapping(
+                self.space.to_le_bytes().as_ptr(),
+                dst.add(52 + seed_bytes.len()),
+                size_of::<u64>(),
+            );
 
-        write_bytes(
-            // SAFETY: instruction data allocated space for the owner address.
-            unsafe { instruction_data.get_unchecked_mut(offset + 16..offset + 48) },
-            self.owner.as_ref(),
-        );
+            copy_nonoverlapping(
+                self.owner.as_ref().as_ptr(),
+                dst.add(60 + seed_bytes.len()),
+                ADDRESS_BYTES,
+            );
+        }
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            // SAFETY: The instruction data is initialized.
-            data: unsafe { from_raw_parts(instruction_data.as_ptr() as *const _, offset + 48) },
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 3) },
+            // SAFETY: `instruction_data` was initialized.
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 92 + seed_bytes.len()) },
         };
 
-        invoke_signed(
-            &instruction,
-            &[self.from, self.to, self.base.unwrap_or(self.from)],
-            signers,
-        )
+        if self.from.is_borrowed() | self.to.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 3];
+        CpiAccount::init_from_account_view(self.from, &mut accounts[0]);
+        CpiAccount::init_from_account_view(self.to, &mut accounts[1]);
+        CpiAccount::init_from_account_view(self.base.unwrap_or(self.from), &mut accounts[2]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(
+                &instruction,
+                from_raw_parts(accounts.as_ptr() as _, 3),
+                signers,
+            )
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/initialize_nonce_account.rs
+++ b/programs/system/src/instructions/initialize_nonce_account.rs
@@ -1,7 +1,12 @@
-use pinocchio::{
-    cpi::invoke,
-    instruction::{InstructionAccount, InstructionView},
-    AccountView, Address, ProgramResult,
+use {
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
+    pinocchio::{
+        cpi::{invoke_signed_unchecked, CpiAccount},
+        error::ProgramError,
+        instruction::{InstructionAccount, InstructionView},
+        AccountView, Address, ProgramResult,
+    },
+    solana_address::ADDRESS_BYTES,
 };
 
 /// Drive state of Uninitialized nonce account to Initialized, setting the nonce
@@ -17,51 +22,74 @@ use pinocchio::{
 ///   0. `[WRITE]` Nonce account
 ///   1. `[]` Recent blockhashes sysvar
 ///   2. `[]` Rent sysvar
-pub struct InitializeNonceAccount<'a, 'b> {
+pub struct InitializeNonceAccount<'account, 'address> {
     /// Nonce account.
-    pub account: &'a AccountView,
+    pub account: &'account AccountView,
 
     /// Recent blockhashes sysvar.
-    pub recent_blockhashes_sysvar: &'a AccountView,
+    pub recent_blockhashes_sysvar: &'account AccountView,
 
     /// Rent sysvar.
-    pub rent_sysvar: &'a AccountView,
+    pub rent_sysvar: &'account AccountView,
 
     /// Indicates the entity authorized to execute nonce
     /// instruction on the account
-    pub authority: &'b Address,
+    pub authority: &'address Address,
 }
 
 impl InitializeNonceAccount<'_, '_> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 6;
+
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 3] = [
-            InstructionAccount::writable(self.account.address()),
-            InstructionAccount::readonly(self.recent_blockhashes_sysvar.address()),
-            InstructionAccount::readonly(self.rent_sysvar.address()),
-        ];
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 3];
+        instruction_accounts[0].write(InstructionAccount::writable(self.account.address()));
+        instruction_accounts[1].write(InstructionAccount::readonly(
+            self.recent_blockhashes_sysvar.address(),
+        ));
+        instruction_accounts[2].write(InstructionAccount::readonly(self.rent_sysvar.address()));
 
         // instruction data
         // - [0..4 ]: instruction discriminator
         // - [4..36]: authority address
-        let mut instruction_data = [0; 36];
-        instruction_data[0] = 6;
-        instruction_data[4..36].copy_from_slice(self.authority.as_array());
+        let mut instruction_data = [const { MaybeUninit::<u8>::uninit() }; 36];
+        // SAFETY: All writes are within bounds of the allocated data.
+        unsafe {
+            let dst = instruction_data.as_mut_ptr() as *mut u8;
+
+            copy_nonoverlapping(
+                Self::DISCRIMINATOR.to_le_bytes().as_ptr(),
+                dst,
+                size_of::<u32>(),
+            );
+
+            copy_nonoverlapping(self.authority.as_ref().as_ptr(), dst.add(4), ADDRESS_BYTES);
+        }
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            data: &instruction_data,
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 3) },
+            // SAFETY: `instruction_data` was initialized.
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 36) },
         };
 
-        invoke(
-            &instruction,
-            &[
-                self.account,
-                self.recent_blockhashes_sysvar,
-                self.rent_sysvar,
-            ],
-        )
+        if self.account.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 3];
+        CpiAccount::init_from_account_view(self.account, &mut accounts[0]);
+        CpiAccount::init_from_account_view(self.recent_blockhashes_sysvar, &mut accounts[1]);
+        CpiAccount::init_from_account_view(self.rent_sysvar, &mut accounts[2]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(&instruction, from_raw_parts(accounts.as_ptr() as _, 3), &[])
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/mod.rs
+++ b/programs/system/src/instructions/mod.rs
@@ -13,24 +13,9 @@ mod transfer_with_seed;
 mod upgrade_nonce_account;
 mod withdraw_nonce_account;
 
-use core::mem::MaybeUninit;
 pub use {
     advance_nonce_account::*, allocate::*, allocate_with_seed::*, assign::*, assign_with_seed::*,
     authorize_nonce_account::*, create_account::*, create_account_allow_prefund::*,
     create_account_with_seed::*, initialize_nonce_account::*, transfer::*, transfer_with_seed::*,
     upgrade_nonce_account::*, withdraw_nonce_account::*,
 };
-
-const UNINIT_BYTE: MaybeUninit<u8> = MaybeUninit::<u8>::uninit();
-
-#[inline(always)]
-fn write_bytes(destination: &mut [MaybeUninit<u8>], source: &[u8]) {
-    let len = destination.len().min(source.len());
-    // SAFETY:
-    // - Both pointers have alignment 1.
-    // - For valid (non-UB) references, the borrow checker guarantees no overlap.
-    // - `len` is bounded by both slice lengths.
-    unsafe {
-        core::ptr::copy_nonoverlapping(source.as_ptr(), destination.as_mut_ptr() as *mut u8, len);
-    }
-}

--- a/programs/system/src/instructions/transfer.rs
+++ b/programs/system/src/instructions/transfer.rs
@@ -1,7 +1,11 @@
-use pinocchio::{
-    cpi::{invoke_signed, Signer},
-    instruction::{InstructionAccount, InstructionView},
-    AccountView, ProgramResult,
+use {
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
+    pinocchio::{
+        cpi::{invoke_signed_unchecked, CpiAccount, Signer},
+        error::ProgramError,
+        instruction::{InstructionAccount, InstructionView},
+        AccountView, ProgramResult,
+    },
 };
 
 /// Transfer lamports.
@@ -9,18 +13,21 @@ use pinocchio::{
 /// ### Accounts:
 ///   0. `[WRITE, SIGNER]` Funding account
 ///   1. `[WRITE]` Recipient account
-pub struct Transfer<'a> {
+pub struct Transfer<'account> {
     /// Funding account.
-    pub from: &'a AccountView,
+    pub from: &'account AccountView,
 
     /// Recipient account.
-    pub to: &'a AccountView,
+    pub to: &'account AccountView,
 
     /// Amount of lamports to transfer.
     pub lamports: u64,
 }
 
 impl Transfer<'_> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 2;
+
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_signed(&[])
@@ -28,25 +35,57 @@ impl Transfer<'_> {
 
     #[inline(always)]
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 2] = [
-            InstructionAccount::writable_signer(self.from.address()),
-            InstructionAccount::writable(self.to.address()),
-        ];
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 2];
+        instruction_accounts[0].write(InstructionAccount::writable_signer(self.from.address()));
+        instruction_accounts[1].write(InstructionAccount::writable(self.to.address()));
 
         // instruction data
         // - [0..4 ]: instruction discriminator
         // - [4..12]: lamports amount
-        let mut instruction_data = [0; 12];
-        instruction_data[0] = 2;
-        instruction_data[4..12].copy_from_slice(&self.lamports.to_le_bytes());
+        let mut instruction_data = [const { MaybeUninit::<u8>::uninit() }; 12];
+        // SAFETY: All writes are within bounds of the allocated data.
+        unsafe {
+            let dst = instruction_data.as_mut_ptr() as *mut u8;
+
+            copy_nonoverlapping(
+                Self::DISCRIMINATOR.to_le_bytes().as_ptr(),
+                dst,
+                size_of::<u32>(),
+            );
+
+            copy_nonoverlapping(
+                self.lamports.to_le_bytes().as_ptr(),
+                dst.add(4),
+                size_of::<u64>(),
+            );
+        }
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            data: &instruction_data,
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 2) },
+            // SAFETY: `instruction_data` was initialized.
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 12) },
         };
 
-        invoke_signed(&instruction, &[self.from, self.to], signers)
+        if self.from.is_borrowed() | self.to.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 2];
+        CpiAccount::init_from_account_view(self.from, &mut accounts[0]);
+        CpiAccount::init_from_account_view(self.to, &mut accounts[1]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(
+                &instruction,
+                from_raw_parts(accounts.as_ptr() as _, 2),
+                signers,
+            )
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/transfer_with_seed.rs
+++ b/programs/system/src/instructions/transfer_with_seed.rs
@@ -1,13 +1,13 @@
 use {
-    crate::instructions::{write_bytes, UNINIT_BYTE},
-    core::slice::from_raw_parts,
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
     pinocchio::{
         address::MAX_SEED_LEN,
-        cpi::{invoke_signed, Signer},
+        cpi::{invoke_signed_unchecked, CpiAccount, Signer},
         error::ProgramError,
         instruction::{InstructionAccount, InstructionView},
         AccountView, Address, ProgramResult,
     },
+    solana_address::ADDRESS_BYTES,
 };
 
 /// Transfer lamports from a derived address.
@@ -16,31 +16,34 @@ use {
 ///   0. `[WRITE]` Funding account
 ///   1. `[SIGNER]` Base for funding account
 ///   2. `[WRITE]` Recipient account
-pub struct TransferWithSeed<'a, 'b, 'c> {
+pub struct TransferWithSeed<'account, 'address, 'seed> {
     /// Funding account.
-    pub from: &'a AccountView,
+    pub from: &'account AccountView,
 
     /// Base account.
     ///
     /// The account matching the base [`Address`] below must be provided as
     /// a signer, but may be the same as the funding account and provided
     /// as account 0.
-    pub base: &'a AccountView,
+    pub base: &'account AccountView,
 
     /// Recipient account.
-    pub to: &'a AccountView,
+    pub to: &'account AccountView,
 
     /// Amount of lamports to transfer.
     pub lamports: u64,
 
     /// String of ASCII chars, no longer than [`MAX_SEED_LEN`](https://docs.rs/solana-address/latest/solana_address/constant.MAX_SEED_LEN.html).
-    pub seed: &'b str,
+    pub seed: &'seed str,
 
     /// Address of program that will own the new account.
-    pub owner: &'c Address,
+    pub owner: &'address Address,
 }
 
 impl TransferWithSeed<'_, '_, '_> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 11;
+
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_signed(&[])
@@ -48,14 +51,15 @@ impl TransferWithSeed<'_, '_, '_> {
 
     #[inline(always)]
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 3] = [
-            InstructionAccount::writable(self.from.address()),
-            InstructionAccount::readonly_signer(self.base.address()),
-            InstructionAccount::writable(self.to.address()),
-        ];
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 3];
+        instruction_accounts[0].write(InstructionAccount::writable(self.from.address()));
+        instruction_accounts[1].write(InstructionAccount::readonly_signer(self.base.address()));
+        instruction_accounts[2].write(InstructionAccount::writable(self.to.address()));
 
-        if self.seed.len() > MAX_SEED_LEN {
+        let seed_bytes = self.seed.as_bytes();
+
+        if seed_bytes.len() > MAX_SEED_LEN {
             return Err(ProgramError::InvalidInstructionData);
         }
 
@@ -65,38 +69,64 @@ impl TransferWithSeed<'_, '_, '_> {
         // - [12..20]: seed length
         // - [20..  ]: seed (max 32)
         // - [.. +32]: owner address
-        let mut instruction_data = [UNINIT_BYTE; 84];
+        let mut instruction_data = [const { MaybeUninit::<u8>::uninit() }; 84];
+        // SAFETY: All writes are within bounds of the allocated data.
+        unsafe {
+            let dst = instruction_data.as_mut_ptr() as *mut u8;
 
-        write_bytes(&mut instruction_data[..4], &[11, 0, 0, 0]);
+            copy_nonoverlapping(
+                Self::DISCRIMINATOR.to_le_bytes().as_ptr(),
+                dst,
+                size_of::<u32>(),
+            );
 
-        write_bytes(&mut instruction_data[4..12], &self.lamports.to_le_bytes());
+            copy_nonoverlapping(
+                self.lamports.to_le_bytes().as_ptr(),
+                dst.add(4),
+                size_of::<u64>(),
+            );
 
-        write_bytes(
-            &mut instruction_data[12..20],
-            &u64::to_le_bytes(self.seed.len() as u64),
-        );
+            copy_nonoverlapping(
+                u64::to_le_bytes(seed_bytes.len() as u64).as_ptr(),
+                dst.add(12),
+                size_of::<u64>(),
+            );
 
-        let offset = 20 + self.seed.len();
-        write_bytes(
-            // SAFETY: instruction data allocated `MAX_SEED_LEN` bytes
-            // for the seed.
-            unsafe { instruction_data.get_unchecked_mut(20..offset) },
-            self.seed.as_bytes(),
-        );
+            copy_nonoverlapping(seed_bytes.as_ptr(), dst.add(20), seed_bytes.len());
 
-        write_bytes(
-            // SAFETY: instruction data allocated space for the owner address.
-            unsafe { instruction_data.get_unchecked_mut(offset..offset + 32) },
-            self.owner.as_ref(),
-        );
+            copy_nonoverlapping(
+                self.owner.as_ref().as_ptr(),
+                dst.add(20 + seed_bytes.len()),
+                ADDRESS_BYTES,
+            );
+        }
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            // SAFETY: The instruction data is initialized.
-            data: unsafe { from_raw_parts(instruction_data.as_ptr() as *const _, offset + 32) },
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 3) },
+            // SAFETY: `instruction_data` was initialized.
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 52 + seed_bytes.len()) },
         };
 
-        invoke_signed(&instruction, &[self.from, self.base, self.to], signers)
+        if self.from.is_borrowed() | self.to.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 3];
+        CpiAccount::init_from_account_view(self.from, &mut accounts[0]);
+        CpiAccount::init_from_account_view(self.base, &mut accounts[1]);
+        CpiAccount::init_from_account_view(self.to, &mut accounts[2]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(
+                &instruction,
+                from_raw_parts(accounts.as_ptr() as _, 3),
+                signers,
+            )
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/upgrade_nonce_account.rs
+++ b/programs/system/src/instructions/upgrade_nonce_account.rs
@@ -1,7 +1,11 @@
-use pinocchio::{
-    cpi::invoke,
-    instruction::{InstructionAccount, InstructionView},
-    AccountView, ProgramResult,
+use {
+    core::{mem::MaybeUninit, slice::from_raw_parts},
+    pinocchio::{
+        cpi::{invoke_signed_unchecked, CpiAccount},
+        error::ProgramError,
+        instruction::{InstructionAccount, InstructionView},
+        AccountView, ProgramResult,
+    },
 };
 
 /// One-time idempotent upgrade of legacy nonce versions in order to bump
@@ -9,25 +13,40 @@ use pinocchio::{
 ///
 /// ### Accounts:
 ///   0. `[WRITE]` Nonce account
-pub struct UpgradeNonceAccount<'a> {
+pub struct UpgradeNonceAccount<'account> {
     /// Nonce account.
-    pub account: &'a AccountView,
+    pub account: &'account AccountView,
 }
 
 impl UpgradeNonceAccount<'_> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 12;
+
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 1] =
-            [InstructionAccount::writable(self.account.address())];
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 1];
+        instruction_accounts[0].write(InstructionAccount::writable(self.account.address()));
 
-        // instruction
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            data: &[12, 0, 0, 0],
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 1) },
+            data: &Self::DISCRIMINATOR.to_le_bytes(),
         };
 
-        invoke(&instruction, &[self.account])
+        if self.account.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 1];
+        CpiAccount::init_from_account_view(self.account, &mut accounts[0]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(&instruction, from_raw_parts(accounts.as_ptr() as _, 1), &[])
+        };
+
+        Ok(())
     }
 }

--- a/programs/system/src/instructions/withdraw_nonce_account.rs
+++ b/programs/system/src/instructions/withdraw_nonce_account.rs
@@ -1,7 +1,11 @@
-use pinocchio::{
-    cpi::{invoke_signed, Signer},
-    instruction::{InstructionAccount, InstructionView},
-    AccountView, ProgramResult,
+use {
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
+    pinocchio::{
+        cpi::{invoke_signed_unchecked, CpiAccount, Signer},
+        error::ProgramError,
+        instruction::{InstructionAccount, InstructionView},
+        AccountView, ProgramResult,
+    },
 };
 
 /// Withdraw funds from a nonce account.
@@ -15,21 +19,21 @@ use pinocchio::{
 ///   2. `[]` Recent blockhashes sysvar
 ///   3. `[]` Rent sysvar
 ///   4. `[SIGNER]` Nonce authority
-pub struct WithdrawNonceAccount<'a> {
+pub struct WithdrawNonceAccount<'account> {
     /// Nonce account.
-    pub account: &'a AccountView,
+    pub account: &'account AccountView,
 
     /// Recipient account.
-    pub recipient: &'a AccountView,
+    pub recipient: &'account AccountView,
 
     /// Recent blockhashes sysvar.
-    pub recent_blockhashes_sysvar: &'a AccountView,
+    pub recent_blockhashes_sysvar: &'account AccountView,
 
     /// Rent sysvar.
-    pub rent_sysvar: &'a AccountView,
+    pub rent_sysvar: &'account AccountView,
 
     /// Nonce authority.
-    pub authority: &'a AccountView,
+    pub authority: &'account AccountView,
 
     /// Lamports to withdraw.
     ///
@@ -39,6 +43,9 @@ pub struct WithdrawNonceAccount<'a> {
 }
 
 impl WithdrawNonceAccount<'_> {
+    /// The instruction discriminator.
+    pub const DISCRIMINATOR: u32 = 5;
+
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_signed(&[])
@@ -46,38 +53,67 @@ impl WithdrawNonceAccount<'_> {
 
     #[inline(always)]
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
-        // Instruction accounts
-        let instruction_accounts: [InstructionAccount; 5] = [
-            InstructionAccount::writable(self.account.address()),
-            InstructionAccount::writable(self.recipient.address()),
-            InstructionAccount::readonly(self.recent_blockhashes_sysvar.address()),
-            InstructionAccount::readonly(self.rent_sysvar.address()),
-            InstructionAccount::readonly_signer(self.authority.address()),
-        ];
+        // Instruction accounts.
+        let mut instruction_accounts = [const { MaybeUninit::<InstructionAccount>::uninit() }; 5];
+        instruction_accounts[0].write(InstructionAccount::writable(self.account.address()));
+        instruction_accounts[1].write(InstructionAccount::writable(self.recipient.address()));
+        instruction_accounts[2].write(InstructionAccount::readonly(
+            self.recent_blockhashes_sysvar.address(),
+        ));
+        instruction_accounts[3].write(InstructionAccount::readonly(self.rent_sysvar.address()));
+        instruction_accounts[4].write(InstructionAccount::readonly_signer(
+            self.authority.address(),
+        ));
 
         // instruction data
         // - [0..4 ]: instruction discriminator
         // - [4..12]: lamports
-        let mut instruction_data = [0; 12];
-        instruction_data[0] = 5;
-        instruction_data[4..12].copy_from_slice(&self.lamports.to_le_bytes());
+        let mut instruction_data = [const { MaybeUninit::<u8>::uninit() }; 12];
+        // SAFETY: All writes are within bounds of the allocated data.
+        unsafe {
+            let dst = instruction_data.as_mut_ptr() as *mut u8;
+
+            copy_nonoverlapping(
+                Self::DISCRIMINATOR.to_le_bytes().as_ptr(),
+                dst,
+                size_of::<u32>(),
+            );
+
+            copy_nonoverlapping(
+                self.lamports.to_le_bytes().as_ptr(),
+                dst.add(4),
+                size_of::<u64>(),
+            );
+        }
 
         let instruction = InstructionView {
             program_id: &crate::ID,
-            accounts: &instruction_accounts,
-            data: &instruction_data,
+            // SAFETY: `instruction_accounts` was initialized.
+            accounts: unsafe { from_raw_parts(instruction_accounts.as_ptr() as _, 5) },
+            // SAFETY: `instruction_data` was initialized.
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 12) },
         };
 
-        invoke_signed(
-            &instruction,
-            &[
-                self.account,
-                self.recipient,
-                self.recent_blockhashes_sysvar,
-                self.rent_sysvar,
-                self.authority,
-            ],
-            signers,
-        )
+        if self.account.is_borrowed() | self.recipient.is_borrowed() {
+            return Err(ProgramError::AccountBorrowFailed);
+        }
+
+        let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; 5];
+        CpiAccount::init_from_account_view(self.account, &mut accounts[0]);
+        CpiAccount::init_from_account_view(self.recipient, &mut accounts[1]);
+        CpiAccount::init_from_account_view(self.recent_blockhashes_sysvar, &mut accounts[2]);
+        CpiAccount::init_from_account_view(self.rent_sysvar, &mut accounts[3]);
+        CpiAccount::init_from_account_view(self.authority, &mut accounts[4]);
+
+        // SAFETY: `accounts` was initialized and not borrowed.
+        unsafe {
+            invoke_signed_unchecked(
+                &instruction,
+                from_raw_parts(accounts.as_ptr() as _, 5),
+                signers,
+            )
+        };
+
+        Ok(())
     }
 }


### PR DESCRIPTION
### Problem

Currently the CPI helpers include more validation than needed. For example, when preparing for a CPI, helpers already guarantee that accounts are set in the correct order. Yet, they use `invoke_signed`, which will validate that accounts are in the expected order by performing an address comparison – this is unnecessary.

### Solution

Update the CPI logic to use `invoke_signed_unchecked`, which does not include any of the unnecessary validation. There is an improvement of about `~200` CUs over the current version, since they are also using the improved `CpiAccount` initialization from https://github.com/anza-xyz/solana-sdk/pull/650.