### PR TITLE
programs/token-2022: Fix `Mint` owner check

### DIFF
--- a/programs/token-2022/src/state/mint.rs
+++ b/programs/token-2022/src/state/mint.rs
@@ -46,8 +46,8 @@ impl Mint {
     /// borrowing the account data.
     #[inline]
     pub fn from_account_view(account_view: &AccountView) -> Result<Ref<'_, Mint>, ProgramError> {
-        if account_view.data_len() < Self::BASE_LEN {
-            return Err(ProgramError::InvalidAccountData);
+        if !account_view.owned_by(&ID) {
+            return Err(ProgramError::InvalidAccountOwner);
         }
 
         let bytes = account_view.try_borrow()?;


### PR DESCRIPTION
### Problem

PR #400 wrongly removed the owner check instead of the length check in `Mint::from_account_view`.

### Solution

Add the owner check back and remove the length check, which is done by `validate_account_type`.