### PR TITLE
Add pinocchio-transfer-hook-interface crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pinocchio-transfer-hook-interface"
+version = "0.1.0"
+dependencies = [
+ "sha2",
+ "solana-account-view",
+ "solana-address",
+ "solana-instruction-view",
+ "solana-program-error",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "programs/system",
     "programs/token",
     "programs/token-2022",
+    "programs/transfer-hook-interface",
     "sdk",
 ]
 

--- a/programs/transfer-hook-interface/Cargo.toml
+++ b/programs/transfer-hook-interface/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "pinocchio-transfer-hook-interface"
+description = "Pinocchio helpers for SPL Transfer Hook interface programs"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+readme = "./README.md"
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[lib]
+crate-type = ["rlib"]
+
+[features]
+find-pda = ["solana-address/curve25519"]
+
+[dependencies]
+solana-account-view = { workspace = true }
+solana-address = { workspace = true, features = ["decode"] }
+solana-instruction-view = { workspace = true, features = ["cpi"] }
+solana-program-error = { workspace = true }
+
+[dev-dependencies]
+sha2 = "0.10"
+solana-address = { workspace = true, features = ["curve25519"] }

--- a/programs/transfer-hook-interface/README.md
+++ b/programs/transfer-hook-interface/README.md
@@ -1,0 +1,80 @@
+<p align="center">
+  <code>pinocchio-transfer-hook-interface</code>
+</p>
+
+## Overview
+
+This crate contains [`pinocchio`](https://crates.io/crates/pinocchio)-compatible types and helpers for the [SPL Transfer Hook Interface](https://spl.solana.com/transfer-hook-interface).
+
+It provides everything needed to **build** a transfer hook program and to **invoke** one via CPI, without depending on `solana-program` or the SPL crate itself:
+
+- **Discriminator constants** for `Execute`, `InitializeExtraAccountMetaList`, and `UpdateExtraAccountMetaList` instructions (SHA-256 based, matching SPL).
+- **`ExtraAccountMeta`** — a 35-byte `#[repr(C)]` type binary-compatible with `spl-tlv-account-resolution::ExtraAccountMeta`.
+- **`Seed`** — typed seed components (`Literal`, `InstructionData`, `AccountKey`, `AccountData`) with pack into the 32-byte `address_config` field.
+- **`ExtraAccountMetaList`** — helpers to initialize and read the TLV-encoded extra account metas PDA data.
+- **`Execute`** — a CPI instruction builder for invoking a hook program's `Execute` handler.
+- **PDA derivation** — `get_extra_account_metas_address()` and seed collection helpers.
+
+This is a `no_std` crate.
+
+> **Note:** The API defined in this crate is subject to change.
+
+## Examples
+
+Building a transfer hook program — validating the incoming `Execute` instruction:
+
+```rust
+use pinocchio_transfer_hook_interface::EXECUTE_DISCRIMINATOR;
+
+// In your program's entrypoint:
+let (discriminator, rest) = instruction_data.split_at(8);
+if discriminator == EXECUTE_DISCRIMINATOR {
+    let amount = u64::from_le_bytes(rest[..8].try_into().unwrap());
+    // ... your transfer hook logic
+}
+```
+
+Initializing extra account metas for your hook:
+
+```rust
+use pinocchio_transfer_hook_interface::{
+    EXECUTE_DISCRIMINATOR,
+    state::{ExtraAccountMeta, ExtraAccountMetaList, Seed},
+};
+
+let metas = [
+    ExtraAccountMeta::new_with_pubkey(&my_config_pubkey, false, false),
+    ExtraAccountMeta::new_with_seeds(
+        &[Seed::AccountKey { index: 0 }, Seed::AccountKey { index: 2 }],
+        false,
+        true,
+    )?,
+];
+let size = ExtraAccountMetaList::size_of(metas.len());
+// Write into the PDA's account data:
+ExtraAccountMetaList::init(pda_data, &EXECUTE_DISCRIMINATOR, &metas)?;
+```
+
+Invoking a hook program via CPI:
+
+```rust
+use pinocchio_transfer_hook_interface::instruction::{AdditionalAccount, Execute};
+
+Execute {
+    source,
+    mint,
+    destination,
+    authority,
+    extra_account_metas_pda,
+    additional_accounts: &[
+        AdditionalAccount { account: &config, is_signer: false, is_writable: true },
+    ],
+    program_id: &hook_program_id,
+    amount: 1_000_000,
+}
+.invoke()?;
+```
+
+## License
+
+The code is licensed under the [Apache License Version 2.0](../LICENSE)

--- a/programs/transfer-hook-interface/src/instruction.rs
+++ b/programs/transfer-hook-interface/src/instruction.rs
@@ -1,0 +1,166 @@
+use {
+    crate::EXECUTE_DISCRIMINATOR,
+    core::{mem::MaybeUninit, slice::from_raw_parts},
+    solana_account_view::AccountView,
+    solana_address::Address,
+    solana_instruction_view::{
+        cpi::{invoke_signed_with_bounds, Signer},
+        InstructionAccount, InstructionView,
+    },
+    solana_program_error::ProgramResult,
+};
+
+const UNINIT_BYTE: MaybeUninit<u8> = MaybeUninit::<u8>::uninit();
+
+#[inline(always)]
+fn write_bytes(destination: &mut [MaybeUninit<u8>], source: &[u8]) {
+    let len = destination.len().min(source.len());
+    // SAFETY: Both pointers have alignment 1. For valid references, the
+    // borrow checker guarantees no overlap. `len` is bounded by both
+    // slice lengths.
+    unsafe {
+        core::ptr::copy_nonoverlapping(source.as_ptr(), destination.as_mut_ptr() as *mut u8, len);
+    }
+}
+
+/// An additional account to pass in an Execute CPI, with its
+/// signer/writable flags.
+pub struct AdditionalAccount<'a> {
+    /// The account view.
+    pub account: &'a AccountView,
+    /// Whether this account is a signer.
+    pub is_signer: bool,
+    /// Whether this account is writable.
+    pub is_writable: bool,
+}
+
+/// Invoke the `Execute` instruction on a transfer hook program.
+///
+/// This is the CPI that Token-2022 (or any caller) uses to invoke the
+/// hook program during a transfer. The instruction data is the 8-byte
+/// Execute discriminator followed by the transfer amount as a little-
+/// endian `u64`.
+///
+/// ### Accounts:
+///   0. `[]` Source token account.
+///   1. `[]` Token mint.
+///   2. `[]` Destination token account.
+///   3. `[]` Source token account owner/delegate.
+///   4. `[]` Extra account metas PDA (validation state).
+///   5. ..5+M `[]` Additional accounts from the extra account metas.
+pub struct Execute<'a, 'b> {
+    /// Source token account.
+    pub source: &'a AccountView,
+    /// Token mint.
+    pub mint: &'a AccountView,
+    /// Destination token account.
+    pub destination: &'a AccountView,
+    /// Source account owner/delegate.
+    pub authority: &'a AccountView,
+    /// Extra account metas PDA (validation state).
+    pub extra_account_metas_pda: &'a AccountView,
+    /// Additional accounts required by the hook, with their
+    /// signer/writable flags from the [`ExtraAccountMeta`] entries.
+    pub additional_accounts: &'b [AdditionalAccount<'a>],
+    /// Transfer hook program address.
+    pub program_id: &'b Address,
+    /// Amount of tokens being transferred.
+    pub amount: u64,
+}
+
+/// Maximum number of total accounts for Execute CPI (5 fixed + up to
+/// 30 additional).
+const MAX_EXECUTE_ACCOUNTS: usize = 35;
+
+impl Execute<'_, '_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let additional_len = self.additional_accounts.len();
+        let total_accounts = 5 + additional_len;
+
+        // Instruction accounts: 5 fixed + additional.
+        let mut instruction_accounts =
+            [const { MaybeUninit::<InstructionAccount>::uninit() }; MAX_EXECUTE_ACCOUNTS];
+
+        instruction_accounts[0].write(InstructionAccount::readonly(self.source.address()));
+        instruction_accounts[1].write(InstructionAccount::readonly(self.mint.address()));
+        instruction_accounts[2].write(InstructionAccount::readonly(self.destination.address()));
+        instruction_accounts[3].write(InstructionAccount::readonly(self.authority.address()));
+        instruction_accounts[4].write(InstructionAccount::readonly(
+            self.extra_account_metas_pda.address(),
+        ));
+
+        for (slot, extra) in instruction_accounts[5..]
+            .iter_mut()
+            .zip(self.additional_accounts.iter())
+        {
+            slot.write(InstructionAccount::new(
+                extra.account.address(),
+                extra.is_writable,
+                extra.is_signer,
+            ));
+        }
+
+        // Account views: 5 fixed + additional.
+        const UNINIT_INFO: MaybeUninit<&AccountView> = MaybeUninit::uninit();
+        let mut accounts = [UNINIT_INFO; MAX_EXECUTE_ACCOUNTS];
+
+        // SAFETY: The allocation is valid to the maximum number of
+        // accounts.
+        unsafe {
+            accounts.get_unchecked_mut(0).write(self.source);
+            accounts.get_unchecked_mut(1).write(self.mint);
+            accounts.get_unchecked_mut(2).write(self.destination);
+            accounts.get_unchecked_mut(3).write(self.authority);
+            accounts
+                .get_unchecked_mut(4)
+                .write(self.extra_account_metas_pda);
+
+            for (slot, extra) in accounts
+                .get_unchecked_mut(5..)
+                .iter_mut()
+                .zip(self.additional_accounts.iter())
+            {
+                slot.write(extra.account);
+            }
+        }
+
+        // Instruction data: 8-byte discriminator + 8-byte amount.
+        let mut instruction_data = [UNINIT_BYTE; 16];
+        write_bytes(&mut instruction_data[..8], &EXECUTE_DISCRIMINATOR);
+        write_bytes(&mut instruction_data[8..16], &self.amount.to_le_bytes());
+
+        invoke_signed_with_bounds::<MAX_EXECUTE_ACCOUNTS, _>(
+            &InstructionView {
+                program_id: self.program_id,
+                // SAFETY: `total_accounts` entries are initialized.
+                accounts: unsafe {
+                    from_raw_parts(instruction_accounts.as_ptr() as _, total_accounts)
+                },
+                // SAFETY: instruction data is fully initialized.
+                data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 16) },
+            },
+            // SAFETY: `total_accounts` entries are initialized.
+            unsafe { from_raw_parts(accounts.as_ptr() as *const &AccountView, total_accounts) },
+            signers,
+        )
+    }
+}
+
+/// Derive the extra account metas PDA address for a given mint and
+/// program.
+///
+/// Returns `(address, bump)`.
+#[cfg(feature = "find-pda")]
+#[inline]
+pub fn get_extra_account_metas_address(mint: &Address, program_id: &Address) -> (Address, u8) {
+    Address::find_program_address(
+        &[crate::EXTRA_ACCOUNT_METAS_SEED, mint.as_ref()],
+        program_id,
+    )
+}

--- a/programs/transfer-hook-interface/src/lib.rs
+++ b/programs/transfer-hook-interface/src/lib.rs
@@ -1,0 +1,73 @@
+#![no_std]
+
+pub mod instruction;
+pub mod state;
+
+use solana_address::Address;
+
+/// Namespace for all programs implementing transfer-hook.
+pub const NAMESPACE: &str = "spl-transfer-hook-interface";
+
+/// Seed for the extra account metas PDA.
+pub const EXTRA_ACCOUNT_METAS_SEED: &[u8] = b"extra-account-metas";
+
+/// Discriminator for the `Execute` instruction.
+///
+/// Computed as `SHA256("spl-transfer-hook-interface:execute")[..8]`.
+pub const EXECUTE_DISCRIMINATOR: [u8; 8] = [105, 37, 101, 197, 75, 251, 102, 26];
+
+/// Discriminator for the `InitializeExtraAccountMetaList` instruction.
+///
+/// Computed as
+/// `SHA256("spl-transfer-hook-interface:initialize-extra-account-metas")[..8]`.
+pub const INITIALIZE_EXTRA_ACCOUNT_META_LIST_DISCRIMINATOR: [u8; 8] =
+    [43, 34, 13, 49, 167, 88, 235, 235];
+
+/// Discriminator for the `UpdateExtraAccountMetaList` instruction.
+///
+/// Computed as
+/// `SHA256("spl-transfer-hook-interface:update-extra-account-metas")[..8]`.
+pub const UPDATE_EXTRA_ACCOUNT_META_LIST_DISCRIMINATOR: [u8; 8] =
+    [157, 105, 42, 146, 102, 85, 241, 174];
+
+/// Collect the seeds used to derive the extra account metas PDA.
+#[inline(always)]
+pub fn collect_extra_account_metas_seeds(mint: &Address) -> [&[u8]; 2] {
+    [EXTRA_ACCOUNT_METAS_SEED, mint.as_ref()]
+}
+
+/// Collect the signer seeds for the extra account metas PDA.
+#[inline(always)]
+pub fn collect_extra_account_metas_signer_seeds<'a>(
+    mint: &'a Address,
+    bump_seed: &'a [u8],
+) -> [&'a [u8]; 3] {
+    [EXTRA_ACCOUNT_METAS_SEED, mint.as_ref(), bump_seed]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execute_discriminator() {
+        let hash = <sha2::Sha256 as sha2::Digest>::digest(b"spl-transfer-hook-interface:execute");
+        assert_eq!(EXECUTE_DISCRIMINATOR, hash[..8]);
+    }
+
+    #[test]
+    fn initialize_discriminator() {
+        let hash = <sha2::Sha256 as sha2::Digest>::digest(
+            b"spl-transfer-hook-interface:initialize-extra-account-metas",
+        );
+        assert_eq!(INITIALIZE_EXTRA_ACCOUNT_META_LIST_DISCRIMINATOR, hash[..8]);
+    }
+
+    #[test]
+    fn update_discriminator() {
+        let hash = <sha2::Sha256 as sha2::Digest>::digest(
+            b"spl-transfer-hook-interface:update-extra-account-metas",
+        );
+        assert_eq!(UPDATE_EXTRA_ACCOUNT_META_LIST_DISCRIMINATOR, hash[..8]);
+    }
+}

--- a/programs/transfer-hook-interface/src/state.rs
+++ b/programs/transfer-hook-interface/src/state.rs
@@ -1,0 +1,487 @@
+use solana_program_error::ProgramError;
+
+/// An extra account meta entry as stored in the extra-account-metas PDA.
+///
+/// This is a 35-byte `#[repr(C)]` type that is binary-compatible with the
+/// `ExtraAccountMeta` type in `spl-tlv-account-resolution`.
+///
+/// ## Layout
+///
+/// | Offset | Size | Field              |
+/// |--------|------|--------------------|
+/// | 0      | 1    | `discriminator`    |
+/// | 1      | 32   | `address_config`   |
+/// | 33     | 1    | `is_signer`        |
+/// | 34     | 1    | `is_writable`      |
+///
+/// ## Discriminator values
+///
+/// - `0` — Standard account meta. `address_config` is a 32-byte pubkey.
+/// - `1` — PDA derived from the hook program. `address_config` contains packed
+///   [`Seed`] entries.
+/// - `128..=255` — PDA derived from an external program at index `discriminator
+///   - 128`. `address_config` contains packed [`Seed`] entries.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExtraAccountMeta {
+    /// 0 = standard pubkey, 1 = hook-program PDA, 128+ = external PDA.
+    pub discriminator: u8,
+    /// Either a raw 32-byte pubkey (disc 0) or packed seed config (disc
+    /// 1 / 128+).
+    pub address_config: [u8; 32],
+    /// Whether this account must sign the transaction.
+    pub is_signer: u8,
+    /// Whether this account is writable.
+    pub is_writable: u8,
+}
+
+/// The byte size of a single [`ExtraAccountMeta`].
+pub const EXTRA_ACCOUNT_META_SIZE: usize = 35;
+
+const _: () = assert!(core::mem::size_of::<ExtraAccountMeta>() == EXTRA_ACCOUNT_META_SIZE);
+
+impl ExtraAccountMeta {
+    /// Create an entry for a fixed account (discriminator 0).
+    #[inline]
+    pub const fn new_with_pubkey(pubkey: &[u8; 32], is_signer: bool, is_writable: bool) -> Self {
+        Self {
+            discriminator: 0,
+            address_config: *pubkey,
+            is_signer: is_signer as u8,
+            is_writable: is_writable as u8,
+        }
+    }
+
+    /// Create an entry for a PDA derived from the hook program
+    /// (discriminator 1).
+    ///
+    /// `seeds` are packed into the 32-byte `address_config` field using
+    /// [`Seed::pack_into_address_config`].
+    #[inline]
+    pub fn new_with_seeds(
+        seeds: &[Seed],
+        is_signer: bool,
+        is_writable: bool,
+    ) -> Result<Self, ProgramError> {
+        Ok(Self {
+            discriminator: 1,
+            address_config: Seed::pack_into_address_config(seeds)?,
+            is_signer: is_signer as u8,
+            is_writable: is_writable as u8,
+        })
+    }
+
+    /// Create an entry for a PDA derived from an external program
+    /// (discriminator 128+).
+    ///
+    /// `program_index` is the index of the program account in the
+    /// *entire* accounts list (fixed + extra).
+    #[inline]
+    pub fn new_external_pda_with_seeds(
+        program_index: u8,
+        seeds: &[Seed],
+        is_signer: bool,
+        is_writable: bool,
+    ) -> Result<Self, ProgramError> {
+        Ok(Self {
+            discriminator: program_index
+                .checked_add(128)
+                .ok_or(ProgramError::InvalidArgument)?,
+            address_config: Seed::pack_into_address_config(seeds)?,
+            is_signer: is_signer as u8,
+            is_writable: is_writable as u8,
+        })
+    }
+}
+
+/// A seed component used to derive PDA-based extra account metas.
+///
+/// Seeds are packed into a 32-byte `address_config` field using a
+/// compact TLV encoding. Each variant has a 1-byte type discriminator
+/// followed by its parameters.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Seed {
+    /// A hard-coded literal byte string.
+    ///
+    /// Encoding: `[1, length, ...bytes]`
+    Literal { bytes: [u8; 32], length: u8 },
+
+    /// A slice of the instruction data.
+    ///
+    /// Encoding: `[2, index, length]`
+    InstructionData { index: u8, length: u8 },
+
+    /// The public key of an account at the given index in the accounts
+    /// list.
+    ///
+    /// Encoding: `[3, index]`
+    AccountKey { index: u8 },
+
+    /// A slice of an account's data.
+    ///
+    /// Encoding: `[4, account_index, data_index, length]`
+    AccountData {
+        account_index: u8,
+        data_index: u8,
+        length: u8,
+    },
+}
+
+impl Seed {
+    /// Byte size of this seed when packed (discriminator + payload).
+    #[inline]
+    pub const fn tlv_size(&self) -> usize {
+        match self {
+            Self::Literal { length, .. } => 2 + *length as usize,
+            Self::InstructionData { .. } => 3,
+            Self::AccountKey { .. } => 2,
+            Self::AccountData { .. } => 4,
+        }
+    }
+
+    /// Pack this seed into `dst`. The caller must ensure `dst.len() >=
+    /// self.tlv_size()`.
+    pub fn pack(&self, dst: &mut [u8]) -> Result<(), ProgramError> {
+        match self {
+            Self::Literal { bytes, length } => {
+                let len = *length as usize;
+                if dst.len() < 2 + len {
+                    return Err(ProgramError::InvalidArgument);
+                }
+                dst[0] = 1;
+                dst[1] = *length;
+                dst[2..2 + len].copy_from_slice(&bytes[..len]);
+            }
+            Self::InstructionData { index, length } => {
+                if dst.len() < 3 {
+                    return Err(ProgramError::InvalidArgument);
+                }
+                dst[0] = 2;
+                dst[1] = *index;
+                dst[2] = *length;
+            }
+            Self::AccountKey { index } => {
+                if dst.len() < 2 {
+                    return Err(ProgramError::InvalidArgument);
+                }
+                dst[0] = 3;
+                dst[1] = *index;
+            }
+            Self::AccountData {
+                account_index,
+                data_index,
+                length,
+            } => {
+                if dst.len() < 4 {
+                    return Err(ProgramError::InvalidArgument);
+                }
+                dst[0] = 4;
+                dst[1] = *account_index;
+                dst[2] = *data_index;
+                dst[3] = *length;
+            }
+        }
+        Ok(())
+    }
+
+    /// Pack multiple seeds into a 32-byte `address_config` field.
+    pub fn pack_into_address_config(seeds: &[Self]) -> Result<[u8; 32], ProgramError> {
+        let mut packed = [0u8; 32];
+        let mut offset: usize = 0;
+        for seed in seeds {
+            let size = seed.tlv_size();
+            let end = offset + size;
+            if end > 32 {
+                return Err(ProgramError::InvalidArgument);
+            }
+            seed.pack(&mut packed[offset..end])?;
+            offset = end;
+        }
+        Ok(packed)
+    }
+}
+
+/// Helpers for reading and writing the TLV-encoded extra-account-metas
+/// PDA data.
+///
+/// The on-chain format stored in the extra-account-metas PDA is:
+///
+/// ```text
+/// [8-byte type discriminator][4-byte length]
+///   [4-byte count][35 × count ExtraAccountMeta entries]
+/// ```
+///
+/// The 8-byte type discriminator identifies which instruction the extra
+/// metas are for. For Transfer Hook `Execute`, this is
+/// [`EXECUTE_DISCRIMINATOR`](crate::EXECUTE_DISCRIMINATOR).
+/// The 4-byte length is the byte size of the value section
+/// (count + entries). Inside the value, a 4-byte little-endian count
+/// precedes the array of 35-byte entries.
+pub struct ExtraAccountMetaList;
+
+impl ExtraAccountMetaList {
+    /// TLV header size: 8-byte type discriminator + 4-byte length.
+    const TLV_HEADER_SIZE: usize = 12;
+
+    /// PodSlice header size: 4-byte count.
+    const POD_SLICE_HEADER_SIZE: usize = 4;
+
+    /// Compute the total account data size needed to store `num_items`
+    /// extra account metas in the PDA.
+    #[inline]
+    pub const fn size_of(num_items: usize) -> usize {
+        Self::TLV_HEADER_SIZE + Self::POD_SLICE_HEADER_SIZE + (EXTRA_ACCOUNT_META_SIZE * num_items)
+    }
+
+    /// Initialize the extra-account-metas PDA data buffer.
+    ///
+    /// Writes the full TLV envelope: 8-byte type discriminator,
+    /// 4-byte value length, 4-byte count, and each
+    /// [`ExtraAccountMeta`] entry.
+    ///
+    /// `type_discriminator` identifies which instruction these metas
+    /// are for — typically
+    /// [`EXECUTE_DISCRIMINATOR`](crate::EXECUTE_DISCRIMINATOR).
+    ///
+    /// `buf` must be at least [`Self::size_of(metas.len())`] bytes.
+    pub fn init(
+        buf: &mut [u8],
+        type_discriminator: &[u8; 8],
+        metas: &[ExtraAccountMeta],
+    ) -> Result<(), ProgramError> {
+        let expected = Self::size_of(metas.len());
+        if buf.len() < expected {
+            return Err(ProgramError::AccountDataTooSmall);
+        }
+
+        let value_len = Self::POD_SLICE_HEADER_SIZE + EXTRA_ACCOUNT_META_SIZE * metas.len();
+
+        // TLV header: 8-byte discriminator + 4-byte value length.
+        buf[0..8].copy_from_slice(type_discriminator);
+        buf[8..12].copy_from_slice(&(value_len as u32).to_le_bytes());
+
+        // PodSlice count.
+        buf[12..16].copy_from_slice(&(metas.len() as u32).to_le_bytes());
+
+        // Entries.
+        let mut offset = 16;
+        for meta in metas {
+            buf[offset] = meta.discriminator;
+            buf[offset + 1..offset + 33].copy_from_slice(&meta.address_config);
+            buf[offset + 33] = meta.is_signer;
+            buf[offset + 34] = meta.is_writable;
+            offset += EXTRA_ACCOUNT_META_SIZE;
+        }
+
+        Ok(())
+    }
+
+    /// Read the count of extra account metas from an initialized buffer.
+    ///
+    /// Validates that the TLV type discriminator matches
+    /// `type_discriminator`.
+    ///
+    /// Returns `None` if the buffer is too short or the discriminator
+    /// does not match.
+    #[inline]
+    pub fn count(buf: &[u8], type_discriminator: &[u8; 8]) -> Option<u32> {
+        if buf.len() < 16 {
+            return None;
+        }
+        if buf[0..8] != *type_discriminator {
+            return None;
+        }
+        Some(u32::from_le_bytes([buf[12], buf[13], buf[14], buf[15]]))
+    }
+
+    /// Get a reference to the `i`-th [`ExtraAccountMeta`] in an
+    /// initialized buffer.
+    ///
+    /// Returns `None` if `index` is out of bounds.
+    #[inline]
+    pub fn get<'a>(
+        buf: &'a [u8],
+        type_discriminator: &[u8; 8],
+        index: usize,
+    ) -> Option<&'a ExtraAccountMeta> {
+        let count = Self::count(buf, type_discriminator)? as usize;
+        if index >= count {
+            return None;
+        }
+        let offset = 16 + index * EXTRA_ACCOUNT_META_SIZE;
+        let end = offset + EXTRA_ACCOUNT_META_SIZE;
+        if buf.len() < end {
+            return None;
+        }
+        // SAFETY: ExtraAccountMeta is #[repr(C)] with alignment 1 (all
+        // fields are u8 or [u8; N]), and the slice bounds are verified
+        // above.
+        Some(unsafe { &*(buf[offset..end].as_ptr() as *const ExtraAccountMeta) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use {super::*, crate::EXECUTE_DISCRIMINATOR, alloc::vec};
+
+    #[test]
+    fn seed_pack_literal() {
+        let mut lit_bytes = [0u8; 32];
+        lit_bytes[..5].copy_from_slice(b"hello");
+        let seed = Seed::Literal {
+            bytes: lit_bytes,
+            length: 5,
+        };
+        assert_eq!(seed.tlv_size(), 7);
+        let config = Seed::pack_into_address_config(&[seed]).unwrap();
+        assert_eq!(config[0], 1); // discriminator
+        assert_eq!(config[1], 5); // length
+        assert_eq!(&config[2..7], b"hello");
+    }
+
+    #[test]
+    fn seed_pack_account_key() {
+        let seed = Seed::AccountKey { index: 2 };
+        assert_eq!(seed.tlv_size(), 2);
+        let config = Seed::pack_into_address_config(&[seed]).unwrap();
+        assert_eq!(config[0], 3);
+        assert_eq!(config[1], 2);
+    }
+
+    #[test]
+    fn seed_pack_multiple() {
+        let seeds = [
+            Seed::AccountKey { index: 0 },
+            Seed::AccountKey { index: 2 },
+            Seed::InstructionData {
+                index: 8,
+                length: 8,
+            },
+        ];
+        let config = Seed::pack_into_address_config(&seeds).unwrap();
+        // AccountKey(0): [3, 0]
+        assert_eq!(config[0], 3);
+        assert_eq!(config[1], 0);
+        // AccountKey(2): [3, 2]
+        assert_eq!(config[2], 3);
+        assert_eq!(config[3], 2);
+        // InstructionData(8, 8): [2, 8, 8]
+        assert_eq!(config[4], 2);
+        assert_eq!(config[5], 8);
+        assert_eq!(config[6], 8);
+    }
+
+    #[test]
+    fn seed_pack_overflow() {
+        // 32-byte literal fills the entire config — adding another seed
+        // should fail.
+        let mut lit_bytes = [0u8; 32];
+        lit_bytes[..30].copy_from_slice(&[0xAA; 30]);
+        let seeds = [
+            Seed::Literal {
+                bytes: lit_bytes,
+                length: 30,
+            },
+            Seed::AccountKey { index: 0 },
+        ];
+        assert!(Seed::pack_into_address_config(&seeds).is_err());
+    }
+
+    #[test]
+    fn extra_account_meta_fixed() {
+        let pubkey = [42u8; 32];
+        let meta = ExtraAccountMeta::new_with_pubkey(&pubkey, true, false);
+        assert_eq!(meta.discriminator, 0);
+        assert_eq!(meta.address_config, pubkey);
+        assert_eq!(meta.is_signer, 1);
+        assert_eq!(meta.is_writable, 0);
+    }
+
+    #[test]
+    fn extra_account_meta_pda() {
+        let seeds = [Seed::AccountKey { index: 0 }, Seed::AccountKey { index: 2 }];
+        let meta = ExtraAccountMeta::new_with_seeds(&seeds, false, true).unwrap();
+        assert_eq!(meta.discriminator, 1);
+        assert_eq!(meta.is_signer, 0);
+        assert_eq!(meta.is_writable, 1);
+        assert_eq!(meta.address_config[0], 3); // AccountKey disc
+        assert_eq!(meta.address_config[1], 0); // index 0
+        assert_eq!(meta.address_config[2], 3); // AccountKey disc
+        assert_eq!(meta.address_config[3], 2); // index 2
+    }
+
+    #[test]
+    fn extra_account_meta_external_pda() {
+        let seeds = [Seed::AccountKey { index: 1 }];
+        let meta = ExtraAccountMeta::new_external_pda_with_seeds(5, &seeds, false, true).unwrap();
+        assert_eq!(meta.discriminator, 133); // 128 + 5
+    }
+
+    #[test]
+    fn list_size_of() {
+        // 12 (TLV header) + 4 (count) + 35*2 = 86
+        assert_eq!(ExtraAccountMetaList::size_of(2), 86);
+        // 12 + 4 + 0 = 16
+        assert_eq!(ExtraAccountMetaList::size_of(0), 16);
+    }
+
+    #[test]
+    fn list_init_and_read() {
+        let pubkey_a = [1u8; 32];
+        let pubkey_b = [2u8; 32];
+        let metas = [
+            ExtraAccountMeta::new_with_pubkey(&pubkey_a, true, false),
+            ExtraAccountMeta::new_with_pubkey(&pubkey_b, false, true),
+        ];
+
+        let size = ExtraAccountMetaList::size_of(metas.len());
+        assert_eq!(size, 12 + 4 + 35 * 2); // 86
+
+        let mut buf = vec![0u8; size];
+        ExtraAccountMetaList::init(&mut buf, &EXECUTE_DISCRIMINATOR, &metas).unwrap();
+
+        // Verify TLV header.
+        assert_eq!(&buf[0..8], &EXECUTE_DISCRIMINATOR);
+        let value_len = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
+        assert_eq!(value_len as usize, 4 + 35 * 2);
+
+        assert_eq!(
+            ExtraAccountMetaList::count(&buf, &EXECUTE_DISCRIMINATOR),
+            Some(2)
+        );
+
+        let entry0 = ExtraAccountMetaList::get(&buf, &EXECUTE_DISCRIMINATOR, 0).unwrap();
+        assert_eq!(entry0.discriminator, 0);
+        assert_eq!(entry0.address_config, pubkey_a);
+        assert_eq!(entry0.is_signer, 1);
+        assert_eq!(entry0.is_writable, 0);
+
+        let entry1 = ExtraAccountMetaList::get(&buf, &EXECUTE_DISCRIMINATOR, 1).unwrap();
+        assert_eq!(entry1.address_config, pubkey_b);
+        assert_eq!(entry1.is_signer, 0);
+        assert_eq!(entry1.is_writable, 1);
+
+        assert!(ExtraAccountMetaList::get(&buf, &EXECUTE_DISCRIMINATOR, 2).is_none());
+    }
+
+    #[test]
+    fn list_wrong_discriminator() {
+        let metas = [ExtraAccountMeta::new_with_pubkey(&[1u8; 32], false, false)];
+        let size = ExtraAccountMetaList::size_of(metas.len());
+        let mut buf = vec![0u8; size];
+        ExtraAccountMetaList::init(&mut buf, &EXECUTE_DISCRIMINATOR, &metas).unwrap();
+
+        // Reading with a different discriminator should return None.
+        let wrong_disc = [0u8; 8];
+        assert!(ExtraAccountMetaList::count(&buf, &wrong_disc).is_none());
+    }
+
+    #[test]
+    fn list_buffer_too_small() {
+        let metas = [ExtraAccountMeta::new_with_pubkey(&[0u8; 32], false, false)];
+        let mut buf = [0u8; 10]; // way too small
+        assert!(ExtraAccountMetaList::init(&mut buf, &EXECUTE_DISCRIMINATOR, &metas).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `no_std`, zero-copy **SPL Transfer Hook Interface** crate for the pinocchio ecosystem — completing the Token-2022 extension story alongside `pinocchio-token-2022`.

### Why this matters

Transfer hooks are one of Token-2022's most powerful extensions, enabling programmable compliance, spending policies, and access control at the token level. Today, building a transfer hook in pinocchio requires:

- Manually encoding SPL's TLV binary format (12-byte header + 35-byte entries)
- Computing SHA-256 discriminators by hand
- Hand-rolling CPI builders with `MaybeUninit` arrays and `invoke_signed_with_bounds`

This crate eliminates that friction with a clean, typed API that matches pinocchio conventions.

### What's included

| Component | Description |
|-----------|-------------|
| **Discriminator constants** | `Execute`, `InitializeExtraAccountMetaList`, `UpdateExtraAccountMetaList` — SHA-256 verified in tests |
| **`ExtraAccountMeta`** | 35-byte `#[repr(C)]` type, binary-compatible with `spl-tlv-account-resolution::ExtraAccountMeta` |
| **`Seed`** | Typed seed components (`Literal`, `InstructionData`, `AccountKey`, `AccountData`) with pack into 32-byte `address_config` |
| **`ExtraAccountMetaList`** | TLV-encoded `init` / `count` / `get` helpers matching SPL's exact binary format |
| **`Execute`** | CPI builder using `invoke_signed_with_bounds` for variable-length additional accounts with proper `is_signer`/`is_writable` flags |
| **PDA helpers** | `get_extra_account_metas_address()` (behind `find-pda` feature), seed collection functions |

### Binary compatibility

The TLV format matches SPL exactly:
- 8-byte type discriminator (instruction-keyed, e.g. `EXECUTE_DISCRIMINATOR`)
- 4-byte value length (little-endian)
- 4-byte count + 35-byte entries

`ExtraAccountMeta` is `#[repr(C)]` with alignment 1, identical to SPL's layout.

## Devnet proof — real transfer hook program

This crate is validated by **[Veil](https://github.com/alsk1992/veil)**, a production transfer hook program built entirely in pinocchio that enforces:
- Per-transaction caps, daily/monthly spending limits
- Velocity controls (max N transfers per window)
- Time-of-day windows (UTC hour restrictions)
- Delegation with sub-caps (scoped spending for agents/bots)
- Merkle-proof whitelisting with approval PDAs

Veil uses `pinocchio-transfer-hook-interface` for `ExtraAccountMetaList::init()`, `ExtraAccountMeta::new_with_seeds()`, `Seed` types, and discriminator routing.

**Program ID:** `J39uNr5qGDwFXzZ9w2YtPeVenQRQztLc68QXmFL4Diz1`

| Transaction | Solscan |
|------------|---------|
| Deploy program | [2dkmcLcyrQA...](https://solscan.io/tx/2dkmcLcyrQApqZu8m3k8Hgx72Wa2DFkvhB7tRaZPpohzJeu4Uirh7SeKsdvqNJpoAa4m7n8TX7dEyDRbhmW5nfdR?cluster=devnet) |
| Create Token-2022 mint + hook | [2GnM1RpuGVk...](https://solscan.io/tx/2GnM1RpuGVk9Kog1zB58HJEz73J5nYzemX4kganZb3cai61SLCyYpVbQcePJHTVKbCeXnLFTuCeAao9g627QTjvR?cluster=devnet) |
| Init ExtraAccountMetaList PDA | [533r69XuSwE...](https://solscan.io/tx/533r69XuSwE3i4ZewJcBK2VQCJwf4hYe4Gsj9oLJnA9sSnRAzgexNxgtM5wBcm2zmpwUMR1r1dbjjtq6JGrXiBa2?cluster=devnet) |
| Create policy + tracker | [4Jv6EkYEGqT...](https://solscan.io/tx/4Jv6EkYEGqTd75Mp6XAfAEjRsJRP88sJXdiV4wkhgrtSTTKPJKN31V5bRFCNBNdCUDLAWdpTCmQ2RLEE9aWFEwPn?cluster=devnet) |
| Transfer succeeds (under cap) | [3ToRanf8qKL...](https://solscan.io/tx/3ToRanf8qKLz44Y1zw68M3RMm2QDnrb8rv1aoZJ5ZWr6XXwmXz8TPkCYiKnjHSXcPF62PevuTJhDGpq3ZV6mQAnZ?cluster=devnet) |
| Transfer rejected (over cap) | `custom program error: 0x5601` (AmountExceedsTxCap) |

## Test plan

- [x] 14 unit tests pass (discriminators, seed packing, TLV round-trip, binary layout)
- [x] 0 clippy warnings
- [x] nightly rustfmt clean
- [x] `cargo build-sbf` — compiles as SBF target
- [x] Consumer program (Veil) builds + passes 36 integration tests using this crate
- [x] End-to-end devnet validation: Token-2022 transfer hook invocation with ExtraAccountMeta resolution
