### PR TITLE
programs: Add pinocchio-feature-gate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pinocchio-feature-gate"
+version = "0.1.0"
+dependencies = [
+ "solana-account-view",
+ "solana-address",
+ "solana-instruction-view",
+ "solana-program-error",
+]
+
+[[package]]
 name = "pinocchio-memo"
 version = "0.4.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "programs/associated-token-account",
+    "programs/feature-gate",
     "programs/memo",
     "programs/system",
     "programs/token",

--- a/programs/feature-gate/Cargo.toml
+++ b/programs/feature-gate/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "pinocchio-feature-gate"
+description = "Pinocchio helpers to invoke Feature Gate program instructions"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+readme = "./README.md"
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+solana-account-view = { workspace = true }
+solana-address = { workspace = true, features = ["decode"] }
+solana-instruction-view = { workspace = true, features = ["cpi"] }
+solana-program-error = { workspace = true }

--- a/programs/feature-gate/README.md
+++ b/programs/feature-gate/README.md
@@ -1,0 +1,61 @@
+<p align="center">
+  <code>pinocchio-feature-gate</code>
+</p>
+
+## Overview
+
+This crate contains [`pinocchio`](https://crates.io/crates/pinocchio)-compatible types and helpers for the [SPL Feature Gate program](https://github.com/solana-program/feature-gate), the on-chain program introduced by [SIMD-0089](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0089-programify-feature-gate-program.md) that allows core contributors to revoke pending feature activations.
+
+It provides:
+
+- **Program and account IDs** for the Feature Gate program, the incinerator, and the System program.
+- **`Feature`** — a 9-byte `#[repr(C)]` zero-copy type binary-compatible with the bincode encoding of `Option<u64>` used by the runtime.
+- **`RevokePendingActivation`** — a CPI instruction builder for the program's sole instruction, used to revoke a feature activation that is pending but not yet activated by the runtime.
+
+This is a `no_std` crate.
+
+> **Note:** The API defined in this crate is subject to change.
+
+## Layout of a feature account
+
+| Offset | Size | Field                                                            |
+|:------:|:----:|:-----------------------------------------------------------------|
+| `0`    | `1`  | `Option` tag — `0` for `None` (pending), `1` for `Some` (activated) |
+| `1`    | `8`  | Activation slot (little-endian `u64`, valid when tag is `1`)      |
+
+## Examples
+
+Reading a feature account's activation status from a program:
+
+```rust
+use pinocchio_feature_gate::state::Feature;
+
+let feature = Feature::from_account_view(feature_account)?;
+
+if let Some(slot) = feature.activated_at() {
+    // Feature has been activated by the runtime at `slot`.
+} else {
+    // Feature is pending activation.
+}
+```
+
+Revoking a pending feature activation via CPI:
+
+```rust
+use pinocchio_feature_gate::instructions::RevokePendingActivation;
+
+RevokePendingActivation {
+    feature,
+    incinerator,
+    system_program,
+}
+.invoke()?;
+```
+
+The `feature` account must be a signer and writable, and its lamports
+will be burned to the [incinerator](https://explorer.solana.com/address/1nc1nerator11111111111111111111111111111111)
+at the end of the current block.
+
+## License
+
+The code is licensed under the [Apache License Version 2.0](../LICENSE)

--- a/programs/feature-gate/src/instructions.rs
+++ b/programs/feature-gate/src/instructions.rs
@@ -1,0 +1,90 @@
+//! Feature Gate program instructions.
+
+use {
+    solana_account_view::AccountView,
+    solana_instruction_view::{
+        cpi::{invoke_signed, Signer},
+        InstructionAccount, InstructionView,
+    },
+    solana_program_error::ProgramResult,
+};
+
+/// Discriminator for the `RevokePendingActivation` instruction.
+pub const REVOKE_PENDING_ACTIVATION_DISCRIMINATOR: u8 = 0;
+
+/// Revoke a pending feature activation.
+///
+/// This instruction will burn any lamports in the feature account by
+/// transferring them to the incinerator. A "pending" feature activation
+/// is a feature account that has been allocated and assigned, but
+/// hasn't yet been updated by the runtime with an `activation_slot`.
+///
+/// Features that _have_ been activated by the runtime cannot be
+/// revoked — the instruction will fail with
+/// `FeatureGateError::FeatureAlreadyActivated`.
+///
+/// ### Accounts:
+///   0. `[WRITE, SIGNER]` Feature account.
+///   1. `[WRITE]` Incinerator account
+///      (`1nc1nerator11111111111111111111111111111111`).
+///   2. `[]` System program.
+pub struct RevokePendingActivation<'a> {
+    /// Feature account. Must be writable and signed by the feature
+    /// keypair.
+    pub feature: &'a AccountView,
+    /// Incinerator account. Must be writable.
+    ///
+    /// Lamports transferred here are burned at the end of the current
+    /// block. See [`crate::INCINERATOR_ID`] for the canonical address.
+    pub incinerator: &'a AccountView,
+    /// System program.
+    pub system_program: &'a AccountView,
+}
+
+impl RevokePendingActivation<'_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        // Instruction accounts:
+        //   0. `[w+s]` Feature account
+        //   1. `[w]`   Incinerator
+        //   2. `[]`    System program
+        let instruction_accounts: [InstructionAccount; 3] = [
+            InstructionAccount::writable_signer(self.feature.address()),
+            InstructionAccount::writable(self.incinerator.address()),
+            InstructionAccount::readonly(self.system_program.address()),
+        ];
+
+        // Instruction data is a single discriminator byte.
+        let instruction_data = [REVOKE_PENDING_ACTIVATION_DISCRIMINATOR];
+
+        let instruction = InstructionView {
+            program_id: &crate::ID,
+            accounts: &instruction_accounts,
+            data: &instruction_data,
+        };
+
+        invoke_signed(
+            &instruction,
+            &[self.feature, self.incinerator, self.system_program],
+            signers,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discriminator_matches_spl_reference() {
+        // The SPL Feature Gate program uses discriminator `0` for
+        // `RevokePendingActivation` — the sole instruction of the
+        // program per SIMD-0089.
+        assert_eq!(REVOKE_PENDING_ACTIVATION_DISCRIMINATOR, 0);
+    }
+}

--- a/programs/feature-gate/src/lib.rs
+++ b/programs/feature-gate/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+
+pub mod instructions;
+pub mod state;
+
+use solana_address::{declare_id, Address};
+
+declare_id!("Feature111111111111111111111111111111111111");
+
+/// The incinerator account — lamports credited to this address are burned
+/// at the end of the current block.
+pub const INCINERATOR_ID: Address =
+    Address::from_str_const("1nc1nerator11111111111111111111111111111111");

--- a/programs/feature-gate/src/state.rs
+++ b/programs/feature-gate/src/state.rs
@@ -1,0 +1,201 @@
+//! Feature account state.
+//!
+//! A [`Feature`] account tracks the activation status of a runtime feature
+//! in the Solana cluster. It has the following 9-byte layout, matching
+//! the bincode serialization of `Option<u64>`:
+//!
+//! | Offset | Size | Field                                        |
+//! |:------:|:----:|:---------------------------------------------|
+//! | `0`    | `1`  | `Option` tag — `0` for `None`, `1` for `Some`|
+//! | `1`    | `8`  | Activation slot (little-endian `u64`)        |
+//!
+//! When the runtime activates a feature, the tag is set to `1` and the
+//! activation slot is recorded at offset `1..9`.
+
+use {
+    solana_account_view::{AccountView, Ref},
+    solana_program_error::ProgramError,
+};
+
+/// The tag byte value indicating `Option::Some` (feature activated).
+const SOME_TAG: u8 = 1;
+
+/// State of a feature account.
+///
+/// # Layout
+///
+/// This struct has a fixed serialized size of [`Feature::LEN`] bytes and
+/// is `#[repr(C)]` with `align = 1`, making it safe to reinterpret over
+/// the account data without copying.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct Feature {
+    /// `Option` tag: `0` (`None`) if the feature is pending activation,
+    /// `1` (`Some`) if it has been activated by the runtime.
+    tag: u8,
+    /// Activation slot — only meaningful when [`Self::tag`] is `1`.
+    ///
+    /// Stored as little-endian bytes so the struct remains `align = 1`
+    /// and zero-copy readable on unaligned boundaries.
+    activation_slot: [u8; 8],
+}
+
+// Invariant: the serialized layout must be exactly 9 bytes to match the
+// bincode encoding of `Option<u64>`.
+const _: () = assert!(core::mem::size_of::<Feature>() == 9);
+const _: () = assert!(core::mem::align_of::<Feature>() == 1);
+
+impl Feature {
+    /// The serialized length of a [`Feature`] account, in bytes.
+    pub const LEN: usize = core::mem::size_of::<Self>();
+
+    /// Returns a reference to the [`Feature`] at the start of `data`,
+    /// without copying.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProgramError::InvalidAccountData`] if `data` is shorter
+    /// than [`Feature::LEN`] bytes.
+    #[inline(always)]
+    pub fn from_bytes(data: &[u8]) -> Result<&Self, ProgramError> {
+        if data.len() < Self::LEN {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        // SAFETY: `Feature` is `#[repr(C)]` with `align = 1`, and `data`
+        // is at least `Feature::LEN` bytes long.
+        Ok(unsafe { &*(data.as_ptr() as *const Self) })
+    }
+
+    /// Returns a mutable reference to the [`Feature`] at the start of
+    /// `data`, without copying.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProgramError::InvalidAccountData`] if `data` is shorter
+    /// than [`Feature::LEN`] bytes.
+    #[inline(always)]
+    pub fn from_bytes_mut(data: &mut [u8]) -> Result<&mut Self, ProgramError> {
+        if data.len() < Self::LEN {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        // SAFETY: `Feature` is `#[repr(C)]` with `align = 1`, and `data`
+        // is at least `Feature::LEN` bytes long.
+        Ok(unsafe { &mut *(data.as_mut_ptr() as *mut Self) })
+    }
+
+    /// Borrows a [`Feature`] from the data of `account`.
+    ///
+    /// The returned [`Ref`] keeps the account data immutably borrowed for
+    /// as long as it is alive, mirroring the borrow rules of
+    /// [`AccountView::try_borrow`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProgramError::IncorrectProgramId`] if the account is
+    /// not owned by the Feature Gate program, or
+    /// [`ProgramError::InvalidAccountData`] if the account data is
+    /// shorter than [`Feature::LEN`] bytes.
+    #[inline(always)]
+    pub fn from_account_view(account: &AccountView) -> Result<Ref<'_, Self>, ProgramError> {
+        if !account.owned_by(&crate::ID) {
+            return Err(ProgramError::IncorrectProgramId);
+        }
+
+        let data = account.try_borrow()?;
+        if data.len() < Self::LEN {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(Ref::map(data, |bytes| {
+            // SAFETY: length checked above; `Feature` is `#[repr(C)]`
+            // with `align = 1`.
+            unsafe { &*(bytes.as_ptr() as *const Self) }
+        }))
+    }
+
+    /// Returns the activation slot, or `None` if the feature has not
+    /// been activated.
+    #[inline(always)]
+    pub fn activated_at(&self) -> Option<u64> {
+        if self.tag == SOME_TAG {
+            Some(u64::from_le_bytes(self.activation_slot))
+        } else {
+            None
+        }
+    }
+
+    /// Returns `true` if the feature has been activated by the runtime.
+    #[inline(always)]
+    pub fn is_activated(&self) -> bool {
+        self.tag == SOME_TAG
+    }
+
+    /// Returns the size a [`Feature`] account requires, in bytes.
+    #[inline(always)]
+    pub const fn size_of() -> usize {
+        Self::LEN
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn len_matches_bincode_option_u64() {
+        // bincode encodes `Option<u64>` as 1 tag byte + 8 u64 bytes.
+        assert_eq!(Feature::LEN, 9);
+        assert_eq!(Feature::size_of(), 9);
+    }
+
+    #[test]
+    fn from_bytes_rejects_short() {
+        let too_short = [0u8; 8];
+        assert!(matches!(
+            Feature::from_bytes(&too_short),
+            Err(ProgramError::InvalidAccountData)
+        ));
+    }
+
+    #[test]
+    fn activated_at_reads_little_endian_slot() {
+        // Simulate a feature activated at slot 0x0102030405060708.
+        let mut buf = [0u8; Feature::LEN];
+        buf[0] = 1;
+        buf[1..9].copy_from_slice(&0x0102030405060708u64.to_le_bytes());
+
+        let feature = Feature::from_bytes(&buf).unwrap();
+        assert!(feature.is_activated());
+        assert_eq!(feature.activated_at(), Some(0x0102030405060708));
+    }
+
+    #[test]
+    fn pending_feature_returns_none() {
+        let buf = [0u8; Feature::LEN];
+        let feature = Feature::from_bytes(&buf).unwrap();
+        assert!(!feature.is_activated());
+        assert_eq!(feature.activated_at(), None);
+    }
+
+    #[test]
+    fn max_slot_round_trips() {
+        let mut buf = [0u8; Feature::LEN];
+        buf[0] = 1;
+        buf[1..9].copy_from_slice(&u64::MAX.to_le_bytes());
+
+        let feature = Feature::from_bytes(&buf).unwrap();
+        assert_eq!(feature.activated_at(), Some(u64::MAX));
+    }
+
+    #[test]
+    fn unknown_tag_treated_as_not_activated() {
+        // bincode rejects any tag other than 0 or 1, but our zero-copy
+        // reader is permissive — any non-1 tag is reported as not
+        // activated rather than erroring, which keeps the hot path
+        // branch-free.
+        let mut buf = [0u8; Feature::LEN];
+        buf[0] = 42;
+        let feature = Feature::from_bytes(&buf).unwrap();
+        assert_eq!(feature.activated_at(), None);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `no_std`, zero-copy **SPL Feature Gate** helper crate — the on-chain program introduced by [SIMD-0089](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0089-programify-feature-gate-program.md) that allows core contributors to revoke pending feature activations. There are currently no open or merged PRs in this repository targeting `feature-gate`, so this fills a small but real gap in pinocchio's coverage of native-adjacent programs.

### What's included

| Component | Description |
|-----------|-------------|
| **`Feature`** | 9-byte `#[repr(C)]` zero-copy type binary-compatible with the bincode encoding of `Option<u64>` used by the runtime. `align = 1` with a compile-time size assertion. |
| **`RevokePendingActivation`** | CPI builder for the program's sole instruction (disc `0`), with `invoke` / `invoke_signed` matching the conventions from `pinocchio-system` and `pinocchio-memo`. |
| **`INCINERATOR_ID`** | `const` `Address` for the canonical incinerator (`1nc1nerator11111111111111111111111111111111`), where revoked-feature lamports are sent to be burned. |

### Binary compatibility

The `Feature` struct mirrors the bincode encoding used by the runtime and `solana-feature-gate-interface`:

| Offset | Size | Field |
|:---:|:---:|:---|
| `0` | `1` | `Option` tag — `0` for `None` (pending), `1` for `Some` (activated) |
| `1` | `8` | Activation slot (little-endian `u64`, valid when tag is `1`) |

A `const _: () = assert!(size_of::<Feature>() == 9)` enforces the 9-byte invariant at compile time, and a const-assert on `align_of` keeps the zero-copy reader safe on any byte alignment.

### Scope

This crate deliberately mirrors the minimal footprint of the upstream program — one instruction, one state type. It follows the same structural conventions as the other `programs/*` crates in this repo (pinocchio-system, pinocchio-memo, pinocchio-associated-token-account):

- `no_std`
- `solana-*` workspace dependencies only (no `pinocchio` runtime dep — same as `memo`)
- Instruction builders with `invoke` / `invoke_signed`
- Zero-copy state readers with explicit `from_bytes` and borrow-tracked `from_account_view`

## Test plan

- [x] 8 unit tests pass (discriminator, size, alignment, round-trip of slots including `u64::MAX`, short-slice rejection, unknown-tag handling)
- [x] 0 clippy warnings (`cargo clippy -p pinocchio-feature-gate --all-targets -- -D warnings`)
- [x] `cargo +nightly-2026-01-22 fmt --check` clean
- [x] `cargo build-sbf` — compiles to SBF target
- [x] Full workspace builds (`cargo build`) — does not disturb other crates

## Source of truth

The on-chain program this crate targets is at [`solana-program/feature-gate`](https://github.com/solana-program/feature-gate), program ID `Feature111111111111111111111111111111111111`. Discriminator and account layout match that program's `instruction.rs` and the `Feature` struct in `solana-feature-gate-interface`.
