### PR TITLE
ci: show crate, version, and ref in release approval window

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,6 +79,18 @@ jobs:
         run: |
           pnpm semver ${{ inputs.crate }}
 
+      - name: Summary
+        run: |
+          version=$(awk -F'"' '/^version = /{print $2; exit}' "${CRATE}/Cargo.toml")
+          {
+            echo "Crate: ${CRATE}"
+            echo "Version: ${version}"
+            echo "Ref: ${GITHUB_SHA} (https://github.com/${REPO}/commit/${GITHUB_SHA})"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          CRATE: ${{ inputs.crate }}
+          REPO: ${{ github.repository }}
+
 
   publish_release:
     name: Publish


### PR DESCRIPTION
## Summary

Right now, when someone approves a `prod` release on the Publish workflow, the GitHub approval window doesn't provide any context. This adds a `Summary` step to the `semver_check` job that writes the crate folder, bumped version, and source commit SHA to `$GITHUB_STEP_SUMMARY` before the gated `publish_release` job runs, so the reviewer can see it on the run page.

Output looks like:

Crate: programs/system
Version: 0.6.2
Ref: <sha> (https://github.com/anza-xyz/pinocchio/commit/<sha>)



