### PR TITLE
token-2022: add account-size helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "solana-nullable",
  "solana-program-error",
  "solana-zero-copy",
+ "test-case",
 ]
 
 [[package]]
@@ -364,6 +365,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "test-case-core",
 ]
 
 [[package]]

--- a/programs/token-2022/Cargo.toml
+++ b/programs/token-2022/Cargo.toml
@@ -20,3 +20,4 @@ solana-zero-copy = { workspace = true }
 
 [dev-dependencies]
 solana-address = { workspace = true, features = ["curve25519"] }
+test-case = "3.3.1"

--- a/programs/token-2022/src/state/extension/account_len.rs
+++ b/programs/token-2022/src/state/extension/account_len.rs
@@ -136,20 +136,21 @@ impl SeenExtensions {
     }
 }
 
-/// Computes the byte length of a Token-2022 account for `mint`: the extensions
-/// every account of that mint requires plus any `additional_account_extensions`
-/// (e.g. the `ATA` program adds `ImmutableOwner`).
+/// Computes the byte length a Token-2022 account for `mint` needs, counting the
+/// extensions every account of that mint requires plus any
+/// `additional_account_extensions` (e.g. the `ATA` program adds
+/// `ImmutableOwner`).
 ///
-/// - `Ok(Some(len))`: Sized locally.
-/// - `Ok(None)`: Can't size locally (ext not recognized or don't track a size
-///   for). Defer to `GetAccountDataSize` CPI.
-/// - `Err(..)`: Invalid input (wrong owner, mint-only ext passed as account
-///   ext, invalid mint data bytes, etc).
+/// Returns `Err` whenever the size can't be computed locally. This can be due
+/// to invalid input (wrong owner, a mint-only ext passed as an account ext,
+/// non-mint data) or inputs it can't size (an extension it doesn't recognize
+/// or track a size for). Callers should defer to the token program's
+/// `GetAccountDataSize` if it's not recognized here.
 #[inline]
 pub fn try_calculate_account_len_from_mint(
     mint: &AccountView,
     additional_account_extensions: &[ExtensionType],
-) -> Result<Option<usize>, ProgramError> {
+) -> Result<usize, ProgramError> {
     if !mint.owned_by(&ID) {
         return Err(ProgramError::IncorrectProgramId);
     }
@@ -168,9 +169,7 @@ pub fn try_calculate_account_len_from_mint(
         if seen.insert(ext) {
             has_extensions = true;
             validate_extension_account_type(ext, AccountType::Account)?;
-            let Some(value_len) = extension_value_len(ext) else {
-                return Ok(None); // unrecognized ext
-            };
+            let value_len = extension_value_len(ext).ok_or(ProgramError::InvalidInstructionData)?;
             total_len = total_len
                 .checked_add(TLV_HEADER_LEN + value_len)
                 .ok_or(ProgramError::InvalidInstructionData)?;
@@ -185,32 +184,28 @@ pub fn try_calculate_account_len_from_mint(
 
         // Find what mint extensions are present
         let mut mint_exts = [ExtensionType::Uninitialized; MAX_EXTENSIONS];
-        let Ok(mint_ext_count) = state.write_extension_types(&mut mint_exts) else {
-            return Ok(None);
-        };
+        let mint_ext_count = state.write_extension_types(&mut mint_exts)?;
         for &mint_ext in &mint_exts[..mint_ext_count] {
-            let Some(required) = required_account_extensions_from_mint_extension(mint_ext) else {
-                return Ok(None); // unrecognized ext
-            };
+            let required = required_account_extensions_from_mint_extension(mint_ext)
+                .ok_or(ProgramError::InvalidAccountData)?;
             for &ext in required {
                 if seen.insert(ext) {
                     has_extensions = true;
-                    let Some(value_len) = extension_value_len(ext) else {
-                        return Ok(None); // unrecognized ext
-                    };
+                    let value_len =
+                        extension_value_len(ext).ok_or(ProgramError::InvalidAccountData)?;
                     total_len = total_len
                         .checked_add(TLV_HEADER_LEN + value_len)
-                        .ok_or(ProgramError::InvalidInstructionData)?;
+                        .ok_or(ProgramError::InvalidAccountData)?;
                 }
             }
         }
     }
 
     if !has_extensions {
-        return Ok(Some(Account::BASE_LEN));
+        return Ok(Account::BASE_LEN);
     }
 
-    Ok(Some(adjust_len_for_multisig(total_len)))
+    Ok(adjust_len_for_multisig(total_len))
 }
 
 #[cfg(test)]
@@ -278,14 +273,14 @@ mod tests {
         );
     }
 
-    #[test_case(&[], Ok(Some(Account::BASE_LEN)))] // no exts, bare account
-    #[test_case(&[ExtensionType::ImmutableOwner], Ok(Some(170)))] // tracked ext is sized
-    #[test_case(&[ExtensionType::ImmutableOwner, ExtensionType::ImmutableOwner], Ok(Some(170)))] // duplicates deduped
+    #[test_case(&[], Ok(Account::BASE_LEN))] // no exts, bare account
+    #[test_case(&[ExtensionType::ImmutableOwner], Ok(170))] // tracked ext is sized
+    #[test_case(&[ExtensionType::ImmutableOwner, ExtensionType::ImmutableOwner], Ok(170))] // duplicates deduped
     #[test_case(&[ExtensionType::TransferFeeConfig], Err(ProgramError::InvalidAccountData))] // mint-only ext rejected
-    #[test_case(&[ExtensionType::CpiGuard], Ok(None))] // untracked ext defers to CPI
+    #[test_case(&[ExtensionType::CpiGuard], Err(ProgramError::InvalidInstructionData))] // untracked ext can't be sized
     fn caller_extensions_against_bare_mint(
         caller_exts: &[ExtensionType],
-        expected: Result<Option<usize>, ProgramError>,
+        expected: Result<usize, ProgramError>,
     ) {
         let data = vec![0u8; Mint::BASE_LEN];
         let (_backing, mint) = build_account_view(&ID, &data);
@@ -311,9 +306,8 @@ mod tests {
     }
 
     #[test]
-    fn unparsable_mint_tlv_returns_none() {
-        // A valid mint base whose extension TLV won't parse defers to the token
-        // program (returns `None`) instead of erroring.
+    fn unparsable_mint_tlv_errors() {
+        // A valid mint base whose extension TLV won't parse
         let mut tlv = Vec::new();
         tlv.extend_from_slice(&(ExtensionType::TransferFeeConfig as u16).to_le_bytes());
         tlv.extend_from_slice(&64u16.to_le_bytes());
@@ -322,7 +316,7 @@ mod tests {
 
         assert_eq!(
             try_calculate_account_len_from_mint(&mint, &[ExtensionType::ImmutableOwner]),
-            Ok(None)
+            Err(ProgramError::InvalidAccountData)
         );
     }
 
@@ -367,7 +361,7 @@ mod tests {
 
         assert_eq!(
             try_calculate_account_len_from_mint(&mint, &[]),
-            Ok(Some(expected))
+            Ok(expected)
         );
     }
 
@@ -383,7 +377,7 @@ mod tests {
 
         assert_eq!(
             try_calculate_account_len_from_mint(&mint, &[ExtensionType::ImmutableOwner]),
-            Ok(Some(174))
+            Ok(174)
         );
     }
 }

--- a/programs/token-2022/src/state/extension/account_len.rs
+++ b/programs/token-2022/src/state/extension/account_len.rs
@@ -1,0 +1,389 @@
+use {
+    super::{
+        adjust_len_for_multisig, default_account_state::DefaultAccountStateExtension,
+        permanent_delegate::PermanentDelegateExtension,
+        permissioned_burn::PermissionedBurnExtension, transfer_hook::TransferHookExtension,
+        validate_extension_account_type, ExtensionBaseState, ExtensionType,
+        ImmutableOwnerExtension, NonTransferableAccountExtension, PausableAccountExtension,
+        StateWithExtensions, TransferFeeAmountExtension, TransferHookAccountExtension,
+        MAX_EXTENSIONS, TLV_HEADER_LEN, TLV_START_INDEX,
+    },
+    crate::{
+        state::{Account, AccountType, Mint},
+        ID,
+    },
+    solana_account_view::AccountView,
+    solana_program_error::ProgramError,
+};
+
+/// Returns the fixed byte length of the given extension's value payload,
+/// or `None` if the extension type is not yet supported.
+///
+/// Only a subset of extension types have known sizes registered here.
+/// Unsupported types will cause [`try_calculate_account_len`] to fail.
+#[inline(always)]
+pub const fn extension_value_len(extension_type: ExtensionType) -> Option<usize> {
+    match extension_type {
+        ExtensionType::DefaultAccountState => Some(DefaultAccountStateExtension::LEN),
+        ExtensionType::PermanentDelegate => Some(PermanentDelegateExtension::LEN),
+        ExtensionType::PermissionedBurn => Some(PermissionedBurnExtension::LEN),
+        ExtensionType::TransferHook => Some(TransferHookExtension::LEN),
+        ExtensionType::TransferHookAccount => Some(TransferHookAccountExtension::LEN),
+        ExtensionType::ImmutableOwner => Some(ImmutableOwnerExtension::LEN),
+        ExtensionType::NonTransferableAccount => Some(NonTransferableAccountExtension::LEN),
+        ExtensionType::PausableAccount => Some(PausableAccountExtension::LEN),
+        ExtensionType::TransferFeeAmount => Some(TransferFeeAmountExtension::LEN),
+        _ => None,
+    }
+}
+
+/// Returns the account data length needed for the given extension types.
+///
+/// Only extension types with sizes registered in [`extension_value_len`] are
+/// supported.
+#[inline]
+pub fn try_calculate_account_len<B: ExtensionBaseState>(
+    extension_types: &[ExtensionType],
+) -> Result<usize, ProgramError> {
+    if extension_types.is_empty() {
+        return Ok(B::BASE_LEN);
+    }
+
+    let mut total_len = TLV_START_INDEX;
+    let mut i = 0;
+
+    while i < extension_types.len() {
+        let extension_type = extension_types[i];
+        validate_extension_account_type(extension_type, B::ACCOUNT_TYPE)?;
+
+        let mut j = 0;
+        while j < i {
+            if extension_types[j] == extension_type {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            j += 1;
+        }
+
+        let value_len =
+            extension_value_len(extension_type).ok_or(ProgramError::InvalidInstructionData)?;
+
+        total_len = total_len
+            .checked_add(TLV_HEADER_LEN + value_len)
+            .ok_or(ProgramError::InvalidInstructionData)?;
+        i += 1;
+    }
+
+    Ok(adjust_len_for_multisig(total_len))
+}
+
+/// Given a Token-2022 extension found on a mint, returns the account extensions
+/// that every token account of that mint must have. Returns `None` when the
+/// input isn't a recognized mint extension.
+#[inline]
+pub const fn required_account_extensions_from_mint_extension(
+    mint_extension_type: ExtensionType,
+) -> Option<&'static [ExtensionType]> {
+    match mint_extension_type {
+        // Mint extensions that force every account of the mint to also carry specific extensions
+        ExtensionType::TransferFeeConfig => Some(&[ExtensionType::TransferFeeAmount]),
+        ExtensionType::NonTransferable => Some(&[
+            ExtensionType::NonTransferableAccount,
+            ExtensionType::ImmutableOwner,
+        ]),
+        ExtensionType::TransferHook => Some(&[ExtensionType::TransferHookAccount]),
+        ExtensionType::Pausable => Some(&[ExtensionType::PausableAccount]),
+        // Mint extensions that don't require anything extra on the account side
+        ExtensionType::MintCloseAuthority
+        | ExtensionType::ConfidentialTransferMint
+        | ExtensionType::DefaultAccountState
+        | ExtensionType::InterestBearingConfig
+        | ExtensionType::PermanentDelegate
+        | ExtensionType::ConfidentialTransferFeeConfig
+        | ExtensionType::MetadataPointer
+        | ExtensionType::TokenMetadata
+        | ExtensionType::GroupPointer
+        | ExtensionType::TokenGroup
+        | ExtensionType::GroupMemberPointer
+        | ExtensionType::TokenGroupMember
+        | ExtensionType::ConfidentialMintBurn
+        | ExtensionType::ScaledUiAmount
+        | ExtensionType::PermissionedBurn => Some(&[]),
+        // `Uninitialized`, account extensions, or unrecognized
+        _ => None,
+    }
+}
+
+// `SeenExtensions` relies on the largest discriminant staying less than 32.
+// If more variants are added, this should be widen to `u64`.
+const _: () = assert!(MAX_EXTENSIONS <= u32::BITS as usize);
+const _: () = assert!(ExtensionType::PermissionedBurn as usize == MAX_EXTENSIONS - 1);
+
+/// Set of extension types already counted, one bit per type. An extension's
+/// discriminant is its bit position: `TransferFeeAmount` (value 2) uses bit 2,
+/// `ImmutableOwner` (value 7) uses bit 7, etc.
+#[derive(Default)]
+struct SeenExtensions(u32);
+
+impl SeenExtensions {
+    /// Inserts `extension_type` into the seen struct. Returns `true` if it
+    /// wasn't already present.
+    #[inline(always)]
+    fn insert(&mut self, extension_type: ExtensionType) -> bool {
+        let bit = 1u32 << (extension_type as u32);
+        let is_new = self.0 & bit == 0;
+        self.0 |= bit;
+        is_new
+    }
+}
+
+/// Computes the byte length of a Token-2022 account for `mint`: the extensions
+/// every account of that mint requires plus any `additional_account_extensions`
+/// (e.g. the `ATA` program adds `ImmutableOwner`).
+///
+/// - `Ok(Some(len))`: Sized locally.
+/// - `Ok(None)`: Can't size locally (ext not recognized or don't track a size
+///   for). Defer to `GetAccountDataSize` CPI.
+/// - `Err(..)`: Invalid input (wrong owner, mint-only ext passed as account
+///   ext, invalid mint data bytes, etc).
+#[inline]
+pub fn try_calculate_account_len_from_mint(
+    mint: &AccountView,
+    additional_account_extensions: &[ExtensionType],
+) -> Result<Option<usize>, ProgramError> {
+    if !mint.owned_by(&ID) {
+        return Err(ProgramError::IncorrectProgramId);
+    }
+
+    let mint_data = mint.try_borrow()?;
+
+    let mut total_len: usize = TLV_START_INDEX;
+    let mut has_extensions = false;
+
+    // Prevents double-counting when the caller and a mint extension both require
+    // the same extension.
+    let mut seen = SeenExtensions::default();
+
+    // Step 1: count whatever the caller asked us to include
+    for &ext in additional_account_extensions {
+        if seen.insert(ext) {
+            has_extensions = true;
+            validate_extension_account_type(ext, AccountType::Account)?;
+            let Some(value_len) = extension_value_len(ext) else {
+                return Ok(None); // unrecognized ext
+            };
+            total_len = total_len
+                .checked_add(TLV_HEADER_LEN + value_len)
+                .ok_or(ProgramError::InvalidInstructionData)?;
+        }
+    }
+
+    // Step 2: iterate over the mint's extensions and add to count
+
+    // only parse if there is extra data present
+    if mint_data.len() != Mint::BASE_LEN {
+        let state = StateWithExtensions::<Mint>::from_bytes(&mint_data)?;
+
+        // Find what mint extensions are present
+        let mut mint_exts = [ExtensionType::Uninitialized; MAX_EXTENSIONS];
+        let Ok(mint_ext_count) = state.write_extension_types(&mut mint_exts) else {
+            return Ok(None);
+        };
+        for &mint_ext in &mint_exts[..mint_ext_count] {
+            let Some(required) = required_account_extensions_from_mint_extension(mint_ext) else {
+                return Ok(None); // unrecognized ext
+            };
+            for &ext in required {
+                if seen.insert(ext) {
+                    has_extensions = true;
+                    let Some(value_len) = extension_value_len(ext) else {
+                        return Ok(None); // unrecognized ext
+                    };
+                    total_len = total_len
+                        .checked_add(TLV_HEADER_LEN + value_len)
+                        .ok_or(ProgramError::InvalidInstructionData)?;
+                }
+            }
+        }
+    }
+
+    if !has_extensions {
+        return Ok(Some(Account::BASE_LEN));
+    }
+
+    Ok(Some(adjust_len_for_multisig(total_len)))
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use {
+        super::{
+            super::{
+                extension_account_type,
+                shared_test_helpers::{build_account_view, build_mint_data, push_tlv_entry},
+                ACCOUNT_TYPE_INDEX,
+            },
+            *,
+        },
+        alloc::{vec, vec::Vec},
+        solana_address::Address,
+        test_case::test_case,
+    };
+
+    // --- `SeenExtensions` helper ---
+
+    #[test]
+    fn insert_returns_true_on_first_call() {
+        let mut seen = SeenExtensions::default();
+        assert!(seen.insert(ExtensionType::ImmutableOwner));
+    }
+
+    #[test]
+    fn insert_returns_false_when_already_seen() {
+        let mut seen = SeenExtensions::default();
+        seen.insert(ExtensionType::ImmutableOwner);
+        assert!(!seen.insert(ExtensionType::ImmutableOwner));
+    }
+
+    #[test]
+    fn duplicate_insert_is_idempotent() {
+        let mut seen = SeenExtensions::default();
+        seen.insert(ExtensionType::ImmutableOwner);
+        let after_first = seen.0;
+        seen.insert(ExtensionType::ImmutableOwner);
+        assert_eq!(seen.0, after_first);
+    }
+
+    #[test]
+    fn distinct_extensions_use_distinct_bits() {
+        let mut seen = SeenExtensions::default();
+        seen.insert(ExtensionType::TransferFeeAmount); // bit 2
+        seen.insert(ExtensionType::ImmutableOwner); // bit 7
+        seen.insert(ExtensionType::PausableAccount); // bit 27
+        assert_eq!(seen.0, (1 << 2) | (1 << 7) | (1 << 27));
+    }
+
+    // --- `try_calculate_account_len_from_mint()` ---
+
+    #[test]
+    fn rejects_mint_with_wrong_owner() {
+        let wrong_owner = Address::new_from_array([7u8; 32]);
+        let data = vec![0u8; Mint::BASE_LEN];
+        let (_backing, mint) = build_account_view(&wrong_owner, &data);
+
+        assert_eq!(
+            try_calculate_account_len_from_mint(&mint, &[ExtensionType::ImmutableOwner]),
+            Err(ProgramError::IncorrectProgramId)
+        );
+    }
+
+    #[test_case(&[], Ok(Some(Account::BASE_LEN)))] // no exts, bare account
+    #[test_case(&[ExtensionType::ImmutableOwner], Ok(Some(170)))] // tracked ext is sized
+    #[test_case(&[ExtensionType::ImmutableOwner, ExtensionType::ImmutableOwner], Ok(Some(170)))] // duplicates deduped
+    #[test_case(&[ExtensionType::TransferFeeConfig], Err(ProgramError::InvalidAccountData))] // mint-only ext rejected
+    #[test_case(&[ExtensionType::CpiGuard], Ok(None))] // untracked ext defers to CPI
+    fn caller_extensions_against_bare_mint(
+        caller_exts: &[ExtensionType],
+        expected: Result<Option<usize>, ProgramError>,
+    ) {
+        let data = vec![0u8; Mint::BASE_LEN];
+        let (_backing, mint) = build_account_view(&ID, &data);
+
+        assert_eq!(
+            try_calculate_account_len_from_mint(&mint, caller_exts),
+            expected
+        );
+    }
+
+    #[test]
+    fn rejects_account_typed_data_as_mint() {
+        // Token-2022-owned and long enough to parse as extended data, but the
+        // account-type byte says `Account`, not `Mint`.
+        let mut data = vec![0u8; TLV_START_INDEX];
+        data[ACCOUNT_TYPE_INDEX] = AccountType::Account as u8;
+        let (_backing, mint) = build_account_view(&ID, &data);
+
+        assert_eq!(
+            try_calculate_account_len_from_mint(&mint, &[ExtensionType::ImmutableOwner]),
+            Err(ProgramError::InvalidAccountData)
+        );
+    }
+
+    #[test]
+    fn unparsable_mint_tlv_returns_none() {
+        // A valid mint base whose extension TLV won't parse defers to the token
+        // program (returns `None`) instead of erroring.
+        let mut tlv = Vec::new();
+        tlv.extend_from_slice(&(ExtensionType::TransferFeeConfig as u16).to_le_bytes());
+        tlv.extend_from_slice(&64u16.to_le_bytes());
+        let data = build_mint_data(&tlv);
+        let (_backing, mint) = build_account_view(&ID, &data);
+
+        assert_eq!(
+            try_calculate_account_len_from_mint(&mint, &[ExtensionType::ImmutableOwner]),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn every_mint_extension_maps_to_account_extensions() {
+        for discriminant in 0..MAX_EXTENSIONS as u16 {
+            let Ok(extension_type) = ExtensionType::try_from(discriminant) else {
+                continue;
+            };
+            if extension_account_type(extension_type) != AccountType::Mint {
+                continue;
+            }
+
+            let required = required_account_extensions_from_mint_extension(extension_type)
+                .unwrap_or_else(|| {
+                    panic!("mint extension {extension_type:?} is missing an explicit map arm")
+                });
+
+            for &required_extension in required {
+                assert_eq!(
+                    extension_account_type(required_extension),
+                    AccountType::Account,
+                    "{extension_type:?} requires {required_extension:?}, not an account extension",
+                );
+                assert!(
+                    extension_value_len(required_extension).is_some(),
+                    "{extension_type:?} requires {required_extension:?}, which has no known size",
+                );
+            }
+        }
+    }
+
+    #[test_case(ExtensionType::MintCloseAuthority, Account::BASE_LEN)] // mint-only, no account ext
+    #[test_case(ExtensionType::TransferFeeConfig, 178)] // adds TransferFeeAmount (8)
+    #[test_case(ExtensionType::TransferHook, 171)] // adds TransferHookAccount (1)
+    #[test_case(ExtensionType::Pausable, 170)] // adds PausableAccount (0)
+    fn single_mint_extension_account_len(mint_ext: ExtensionType, expected: usize) {
+        let mut tlv = Vec::new();
+        push_tlv_entry(&mut tlv, mint_ext, &[]);
+        let data = build_mint_data(&tlv);
+        let (_backing, mint) = build_account_view(&ID, &data);
+
+        assert_eq!(
+            try_calculate_account_len_from_mint(&mint, &[]),
+            Ok(Some(expected))
+        );
+    }
+
+    #[test]
+    fn dedups_immutable_owner_against_non_transferable_mint() {
+        // NonTransferable on the mint requires both NonTransferableAccount and
+        // ImmutableOwner. Correct dedup produces 166 (TLV_START_INDEX) + 4
+        // (ImmutableOwner TLV) + 4 (NonTransferableAccount TLV) = 174.
+        let mut tlv = Vec::new();
+        push_tlv_entry(&mut tlv, ExtensionType::NonTransferable, &[]);
+        let data = build_mint_data(&tlv);
+        let (_backing, mint) = build_account_view(&ID, &data);
+
+        assert_eq!(
+            try_calculate_account_len_from_mint(&mint, &[ExtensionType::ImmutableOwner]),
+            Ok(Some(174))
+        );
+    }
+}

--- a/programs/token-2022/src/state/extension/mod.rs
+++ b/programs/token-2022/src/state/extension/mod.rs
@@ -1,9 +1,12 @@
+mod account_len;
 pub mod default_account_state;
 pub mod immutable_owner;
 pub mod non_transferable_account;
 pub mod pausable_account;
 pub mod permanent_delegate;
 pub mod permissioned_burn;
+#[cfg(test)]
+mod shared_test_helpers;
 mod state;
 pub mod transfer_fee_amount;
 pub mod transfer_hook;
@@ -14,6 +17,10 @@ use {
     solana_program_error::ProgramError,
 };
 pub use {
+    account_len::{
+        extension_value_len, required_account_extensions_from_mint_extension,
+        try_calculate_account_len, try_calculate_account_len_from_mint,
+    },
     default_account_state::DefaultAccountStateExtension,
     immutable_owner::ImmutableOwnerExtension,
     non_transferable_account::NonTransferableAccountExtension,
@@ -246,64 +253,4 @@ fn validate_token_extensions_data(data: &[u8]) -> Result<(), ProgramError> {
     }
 
     Ok(())
-}
-
-/// Returns the fixed byte length of the given extension's value payload,
-/// or `None` if the extension type is not yet supported.
-///
-/// Only a subset of extension types have known sizes registered here.
-/// Unsupported types will cause [`try_calculate_account_len`] to fail.
-#[inline(always)]
-pub const fn extension_value_len(extension_type: ExtensionType) -> Option<usize> {
-    match extension_type {
-        ExtensionType::DefaultAccountState => Some(DefaultAccountStateExtension::LEN),
-        ExtensionType::PermanentDelegate => Some(PermanentDelegateExtension::LEN),
-        ExtensionType::PermissionedBurn => Some(PermissionedBurnExtension::LEN),
-        ExtensionType::TransferHook => Some(TransferHookExtension::LEN),
-        ExtensionType::TransferHookAccount => Some(TransferHookAccountExtension::LEN),
-        ExtensionType::ImmutableOwner => Some(ImmutableOwnerExtension::LEN),
-        ExtensionType::NonTransferableAccount => Some(NonTransferableAccountExtension::LEN),
-        ExtensionType::PausableAccount => Some(PausableAccountExtension::LEN),
-        ExtensionType::TransferFeeAmount => Some(TransferFeeAmountExtension::LEN),
-        _ => None,
-    }
-}
-
-/// Returns the account data length needed for the given extension types.
-///
-/// Only extension types with sizes registered in [`extension_value_len`] are
-/// supported.
-#[inline]
-pub fn try_calculate_account_len<B: ExtensionBaseState>(
-    extension_types: &[ExtensionType],
-) -> Result<usize, ProgramError> {
-    if extension_types.is_empty() {
-        return Ok(B::BASE_LEN);
-    }
-
-    let mut total_len = TLV_START_INDEX;
-    let mut i = 0;
-
-    while i < extension_types.len() {
-        let extension_type = extension_types[i];
-        validate_extension_account_type(extension_type, B::ACCOUNT_TYPE)?;
-
-        let mut j = 0;
-        while j < i {
-            if extension_types[j] == extension_type {
-                return Err(ProgramError::InvalidInstructionData);
-            }
-            j += 1;
-        }
-
-        let value_len =
-            extension_value_len(extension_type).ok_or(ProgramError::InvalidInstructionData)?;
-
-        total_len = total_len
-            .checked_add(TLV_HEADER_LEN + value_len)
-            .ok_or(ProgramError::InvalidInstructionData)?;
-        i += 1;
-    }
-
-    Ok(adjust_len_for_multisig(total_len))
 }

--- a/programs/token-2022/src/state/extension/shared_test_helpers.rs
+++ b/programs/token-2022/src/state/extension/shared_test_helpers.rs
@@ -1,0 +1,48 @@
+extern crate alloc;
+
+use {
+    super::{ExtensionType, ACCOUNT_TYPE_INDEX, TLV_START_INDEX},
+    crate::state::AccountType,
+    alloc::{vec, vec::Vec},
+    core::{mem::size_of, ptr::copy_nonoverlapping},
+    solana_account_view::{AccountView, RuntimeAccount, NOT_BORROWED},
+    solana_address::Address,
+};
+
+pub(super) fn push_tlv_entry(buffer: &mut Vec<u8>, extension_type: ExtensionType, value: &[u8]) {
+    buffer.extend_from_slice(&(extension_type as u16).to_le_bytes());
+    buffer.extend_from_slice(&(value.len() as u16).to_le_bytes());
+    buffer.extend_from_slice(value);
+}
+
+pub(super) fn build_mint_data(tlv_data: &[u8]) -> Vec<u8> {
+    let mut data = vec![0u8; TLV_START_INDEX + tlv_data.len()];
+    data[ACCOUNT_TYPE_INDEX] = AccountType::Mint as u8;
+    data[TLV_START_INDEX..].copy_from_slice(tlv_data);
+    data
+}
+
+pub(super) fn build_account_view(owner: &Address, data: &[u8]) -> (Vec<u64>, AccountView) {
+    let runtime_len = size_of::<RuntimeAccount>();
+    let total_len = runtime_len + data.len();
+    let backing_len = total_len.div_ceil(size_of::<u64>());
+    let mut backing = vec![0u64; backing_len];
+    let raw = backing.as_mut_ptr() as *mut RuntimeAccount;
+
+    unsafe {
+        (*raw).borrow_state = NOT_BORROWED;
+        (*raw).is_signer = 0;
+        (*raw).is_writable = 1;
+        (*raw).executable = 0;
+        (*raw).padding = [0; 4];
+        (*raw).address = Address::new_from_array([42u8; 32]);
+        (*raw).owner = owner.clone();
+        (*raw).lamports = 1;
+        (*raw).data_len = data.len() as u64;
+
+        let data_ptr = (raw as *mut u8).add(runtime_len);
+        copy_nonoverlapping(data.as_ptr(), data_ptr, data.len());
+
+        (backing, AccountView::new_unchecked(raw))
+    }
+}

--- a/programs/token-2022/src/state/extension/state.rs
+++ b/programs/token-2022/src/state/extension/state.rs
@@ -432,65 +432,34 @@ mod tests {
         super::*,
         crate::state::{
             extension::{
-                adjust_len_for_multisig, default_account_state::DefaultAccountStateExtension,
-                extension_account_type, is_extension_not_found_error,
+                adjust_len_for_multisig,
+                default_account_state::DefaultAccountStateExtension,
+                extension_account_type,
+                immutable_owner::ImmutableOwnerExtension,
+                is_extension_not_found_error,
+                non_transferable_account::NonTransferableAccountExtension,
+                pausable_account::PausableAccountExtension,
                 permanent_delegate::PermanentDelegateExtension,
-                permissioned_burn::PermissionedBurnExtension, transfer_hook::TransferHookExtension,
-                transfer_hook_account::TransferHookAccountExtension, try_calculate_account_len,
-                TokenError, ACCOUNT_TYPE_INDEX, EXTENSION_NOT_FOUND_ERROR_CODE,
+                permissioned_burn::PermissionedBurnExtension,
+                shared_test_helpers::{build_account_view, build_mint_data, push_tlv_entry},
+                transfer_fee_amount::TransferFeeAmountExtension,
+                transfer_hook::TransferHookExtension,
+                transfer_hook_account::TransferHookAccountExtension,
+                try_calculate_account_len, TokenError, ACCOUNT_TYPE_INDEX,
+                EXTENSION_NOT_FOUND_ERROR_CODE,
             },
-            AccountState, ImmutableOwnerExtension, NonTransferableAccountExtension,
-            PausableAccountExtension, TransferFeeAmountExtension,
+            AccountState,
         },
-        core::{mem::size_of, ptr::copy_nonoverlapping},
-        solana_account_view::{RuntimeAccount, NOT_BORROWED},
+        core::mem::size_of,
         solana_address::Address,
         std::{vec, vec::Vec},
     };
-
-    fn push_tlv_entry(buffer: &mut Vec<u8>, extension_type: ExtensionType, value: &[u8]) {
-        buffer.extend_from_slice(&(extension_type as u16).to_le_bytes());
-        buffer.extend_from_slice(&(value.len() as u16).to_le_bytes());
-        buffer.extend_from_slice(value);
-    }
-
-    fn build_mint_data(tlv_data: &[u8]) -> Vec<u8> {
-        let mut data = vec![0u8; TLV_START_INDEX + tlv_data.len()];
-        data[ACCOUNT_TYPE_INDEX] = AccountType::Mint as u8;
-        data[TLV_START_INDEX..].copy_from_slice(tlv_data);
-        data
-    }
 
     fn build_token_data(tlv_data: &[u8]) -> Vec<u8> {
         let mut data = vec![0u8; TLV_START_INDEX + tlv_data.len()];
         data[ACCOUNT_TYPE_INDEX] = AccountType::Account as u8;
         data[TLV_START_INDEX..].copy_from_slice(tlv_data);
         data
-    }
-
-    fn build_account_view(owner: &Address, data: &[u8]) -> (Vec<u64>, AccountView) {
-        let runtime_len = size_of::<RuntimeAccount>();
-        let total_len = runtime_len + data.len();
-        let backing_len = total_len.div_ceil(size_of::<u64>());
-        let mut backing = vec![0u64; backing_len];
-        let raw = backing.as_mut_ptr() as *mut RuntimeAccount;
-
-        unsafe {
-            (*raw).borrow_state = NOT_BORROWED;
-            (*raw).is_signer = 0;
-            (*raw).is_writable = 1;
-            (*raw).executable = 0;
-            (*raw).padding = [0; 4];
-            (*raw).address = Address::new_from_array([42u8; 32]);
-            (*raw).owner = owner.clone();
-            (*raw).lamports = 1;
-            (*raw).data_len = data.len() as u64;
-
-            let data_ptr = (raw as *mut u8).add(runtime_len);
-            copy_nonoverlapping(data.as_ptr(), data_ptr, data.len());
-
-            (backing, AccountView::new_unchecked(raw))
-        }
     }
 
     #[test]


### PR DESCRIPTION
Adds `extension::account_len` module in `pinocchio-token-2022` for sizing a Token-2022 account. .

 ### Why

Programs like p-ATA want the ability to size token-2022 accounts without the need for paying the CU cost of a `GetAccountDataSize` CPI. Reference: https://github.com/solana-program/associated-token-account/pull/258.

### New method

`try_calculate_account_len_from_mint()` is added to be a utility for optimistic, fast path sizing. If mint data errs, the caller is expected to fallback to `GetAccountSize` CPI. 