### PR TITLE
Add ATA-relevant ext structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /target
+.idea

--- a/programs/token-2022/src/state/extension/immutable_owner.rs
+++ b/programs/token-2022/src/state/extension/immutable_owner.rs
@@ -1,0 +1,20 @@
+use super::{sealed, ExtensionType, ExtensionValue};
+
+/// Immutable owner extension (marker, 0 bytes).
+///
+/// Indicates that the token account's owner authority cannot be changed.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ImmutableOwnerExtension;
+
+impl ImmutableOwnerExtension {
+    pub const LEN: usize = core::mem::size_of::<ImmutableOwnerExtension>();
+}
+
+impl sealed::Sealed for ImmutableOwnerExtension {}
+
+// SAFETY: `ImmutableOwnerExtension` is a zero-sized type with no
+// representation requirements.
+unsafe impl ExtensionValue for ImmutableOwnerExtension {
+    const TYPE: ExtensionType = ExtensionType::ImmutableOwner;
+}

--- a/programs/token-2022/src/state/extension/mod.rs
+++ b/programs/token-2022/src/state/extension/mod.rs
@@ -1,7 +1,11 @@
 pub mod default_account_state;
+pub mod immutable_owner;
+pub mod non_transferable_account;
+pub mod pausable_account;
 pub mod permanent_delegate;
 pub mod permissioned_burn;
 mod state;
+pub mod transfer_fee_amount;
 pub mod transfer_hook;
 pub mod transfer_hook_account;
 
@@ -11,9 +15,13 @@ use {
 };
 pub use {
     default_account_state::DefaultAccountStateExtension,
+    immutable_owner::ImmutableOwnerExtension,
+    non_transferable_account::NonTransferableAccountExtension,
+    pausable_account::PausableAccountExtension,
     permanent_delegate::PermanentDelegateExtension,
     permissioned_burn::PermissionedBurnExtension,
     state::{StateWithExtensions, StateWithExtensionsMut},
+    transfer_fee_amount::TransferFeeAmountExtension,
     transfer_hook::TransferHookExtension,
     transfer_hook_account::TransferHookAccountExtension,
 };
@@ -253,6 +261,10 @@ pub const fn extension_value_len(extension_type: ExtensionType) -> Option<usize>
         ExtensionType::PermissionedBurn => Some(PermissionedBurnExtension::LEN),
         ExtensionType::TransferHook => Some(TransferHookExtension::LEN),
         ExtensionType::TransferHookAccount => Some(TransferHookAccountExtension::LEN),
+        ExtensionType::ImmutableOwner => Some(ImmutableOwnerExtension::LEN),
+        ExtensionType::NonTransferableAccount => Some(NonTransferableAccountExtension::LEN),
+        ExtensionType::PausableAccount => Some(PausableAccountExtension::LEN),
+        ExtensionType::TransferFeeAmount => Some(TransferFeeAmountExtension::LEN),
         _ => None,
     }
 }

--- a/programs/token-2022/src/state/extension/non_transferable_account.rs
+++ b/programs/token-2022/src/state/extension/non_transferable_account.rs
@@ -1,0 +1,22 @@
+use super::{sealed, ExtensionType, ExtensionValue};
+
+/// Non-transferable account extension (marker, 0 bytes).
+///
+/// Required on token accounts of mints with the `NonTransferable` extension.
+/// The mint also forces `ImmutableOwner` on these accounts so the marker
+/// can't be bypassed.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct NonTransferableAccountExtension;
+
+impl NonTransferableAccountExtension {
+    pub const LEN: usize = core::mem::size_of::<NonTransferableAccountExtension>();
+}
+
+impl sealed::Sealed for NonTransferableAccountExtension {}
+
+// SAFETY: `NonTransferableAccountExtension` is a zero-sized type with
+// no representation requirements.
+unsafe impl ExtensionValue for NonTransferableAccountExtension {
+    const TYPE: ExtensionType = ExtensionType::NonTransferableAccount;
+}

--- a/programs/token-2022/src/state/extension/pausable_account.rs
+++ b/programs/token-2022/src/state/extension/pausable_account.rs
@@ -1,0 +1,22 @@
+use super::{sealed, ExtensionType, ExtensionValue};
+
+/// Pausable account extension (marker, 0 bytes).
+///
+/// Required on token accounts of mints with the `Pausable` extension.
+/// Transfers, mints, and burns on this account are rejected while
+/// the mint is paused.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct PausableAccountExtension;
+
+impl PausableAccountExtension {
+    pub const LEN: usize = core::mem::size_of::<PausableAccountExtension>();
+}
+
+impl sealed::Sealed for PausableAccountExtension {}
+
+// SAFETY: `PausableAccountExtension` is a zero-sized type with no
+// representation requirements.
+unsafe impl ExtensionValue for PausableAccountExtension {
+    const TYPE: ExtensionType = ExtensionType::PausableAccount;
+}

--- a/programs/token-2022/src/state/extension/state.rs
+++ b/programs/token-2022/src/state/extension/state.rs
@@ -439,7 +439,8 @@ mod tests {
                 transfer_hook_account::TransferHookAccountExtension, try_calculate_account_len,
                 TokenError, ACCOUNT_TYPE_INDEX, EXTENSION_NOT_FOUND_ERROR_CODE,
             },
-            AccountState,
+            AccountState, ImmutableOwnerExtension, NonTransferableAccountExtension,
+            PausableAccountExtension, TransferFeeAmountExtension,
         },
         core::{mem::size_of, ptr::copy_nonoverlapping},
         solana_account_view::{RuntimeAccount, NOT_BORROWED},
@@ -1136,8 +1137,12 @@ mod tests {
 
     #[test]
     fn spl2022_supported_extension_discriminants_match() {
+        assert_eq!(ExtensionType::TransferFeeAmount as u16, 2);
         assert_eq!(ExtensionType::DefaultAccountState as u16, 6);
+        assert_eq!(ExtensionType::ImmutableOwner as u16, 7);
+        assert_eq!(ExtensionType::NonTransferableAccount as u16, 13);
         assert_eq!(ExtensionType::TransferHookAccount as u16, 15);
+        assert_eq!(ExtensionType::PausableAccount as u16, 27);
         assert_eq!(ExtensionType::PermissionedBurn as u16, 28);
     }
 
@@ -1162,6 +1167,22 @@ mod tests {
             extension_account_type(ExtensionType::PermissionedBurn),
             AccountType::Mint
         );
+        assert_eq!(
+            extension_account_type(ExtensionType::ImmutableOwner),
+            AccountType::Account
+        );
+        assert_eq!(
+            extension_account_type(ExtensionType::NonTransferableAccount),
+            AccountType::Account
+        );
+        assert_eq!(
+            extension_account_type(ExtensionType::PausableAccount),
+            AccountType::Account
+        );
+        assert_eq!(
+            extension_account_type(ExtensionType::TransferFeeAmount),
+            AccountType::Account
+        );
     }
 
     #[test]
@@ -1171,6 +1192,10 @@ mod tests {
         assert_eq!(PermanentDelegateExtension::LEN, 32);
         assert_eq!(PermissionedBurnExtension::LEN, 32);
         assert_eq!(TransferHookExtension::LEN, 64);
+        assert_eq!(ImmutableOwnerExtension::LEN, 0);
+        assert_eq!(NonTransferableAccountExtension::LEN, 0);
+        assert_eq!(PausableAccountExtension::LEN, 0);
+        assert_eq!(TransferFeeAmountExtension::LEN, 8);
     }
 
     #[test]
@@ -1180,6 +1205,10 @@ mod tests {
         assert_eq!(core::mem::align_of::<PermanentDelegateExtension>(), 1);
         assert_eq!(core::mem::align_of::<PermissionedBurnExtension>(), 1);
         assert_eq!(core::mem::align_of::<TransferHookExtension>(), 1);
+        assert_eq!(core::mem::align_of::<ImmutableOwnerExtension>(), 1);
+        assert_eq!(core::mem::align_of::<NonTransferableAccountExtension>(), 1);
+        assert_eq!(core::mem::align_of::<PausableAccountExtension>(), 1);
+        assert_eq!(core::mem::align_of::<TransferFeeAmountExtension>(), 1);
     }
 
     #[test]
@@ -1278,5 +1307,80 @@ mod tests {
         let ext = mint.get_extension::<TransferHookExtension>().unwrap();
         assert_eq!(ext.authority.as_ref().unwrap(), &new_authority);
         assert_eq!(ext.program_id.as_ref().unwrap(), &new_program_id);
+    }
+
+    #[test]
+    fn transfer_fee_amount_extension_read_roundtrip() {
+        let amount: u64 = 1_234_567_890_123;
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(
+            &mut tlv_data,
+            ExtensionType::TransferFeeAmount,
+            &amount.to_le_bytes(),
+        );
+        let data = build_token_data(&tlv_data);
+
+        let account = StateWithExtensions::<Account>::from_bytes(&data).unwrap();
+        let ext = account
+            .get_extension::<TransferFeeAmountExtension>()
+            .unwrap();
+        assert_eq!(u64::from(ext.withheld_amount), amount);
+    }
+
+    #[test]
+    fn transfer_fee_amount_extension_write_then_read_roundtrip() {
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(&mut tlv_data, ExtensionType::TransferFeeAmount, &[0u8; 8]);
+        let mut data = build_token_data(&tlv_data);
+
+        let new_amount: u64 = 987_654_321;
+        let account = StateWithExtensionsMut::<Account>::from_bytes_mut(&mut data).unwrap();
+        account
+            .get_extension_mut::<TransferFeeAmountExtension>()
+            .unwrap()
+            .withheld_amount = new_amount.into();
+
+        let account = StateWithExtensions::<Account>::from_bytes(&data).unwrap();
+        assert_eq!(
+            u64::from(
+                account
+                    .get_extension::<TransferFeeAmountExtension>()
+                    .unwrap()
+                    .withheld_amount
+            ),
+            new_amount,
+        );
+    }
+
+    #[test]
+    fn immutable_owner_extension_present() {
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(&mut tlv_data, ExtensionType::ImmutableOwner, &[]);
+        let data = build_token_data(&tlv_data);
+
+        let account = StateWithExtensions::<Account>::from_bytes(&data).unwrap();
+        account.get_extension::<ImmutableOwnerExtension>().unwrap();
+    }
+
+    #[test]
+    fn non_transferable_account_extension_present() {
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(&mut tlv_data, ExtensionType::NonTransferableAccount, &[]);
+        let data = build_token_data(&tlv_data);
+
+        let account = StateWithExtensions::<Account>::from_bytes(&data).unwrap();
+        account
+            .get_extension::<NonTransferableAccountExtension>()
+            .unwrap();
+    }
+
+    #[test]
+    fn pausable_account_extension_present() {
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(&mut tlv_data, ExtensionType::PausableAccount, &[]);
+        let data = build_token_data(&tlv_data);
+
+        let account = StateWithExtensions::<Account>::from_bytes(&data).unwrap();
+        account.get_extension::<PausableAccountExtension>().unwrap();
     }
 }

--- a/programs/token-2022/src/state/extension/transfer_fee_amount.rs
+++ b/programs/token-2022/src/state/extension/transfer_fee_amount.rs
@@ -1,0 +1,28 @@
+use {
+    super::{sealed, ExtensionType, ExtensionValue},
+    solana_zero_copy::unaligned::U64,
+};
+
+/// Transfer fee amount extension data for token accounts (8 bytes).
+///
+/// Tracks the fees withheld on this account from inbound transfers governed
+/// by the mint's `TransferFeeConfig`. Pending fees accumulate here until the
+/// authority harvests them back to the mint.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct TransferFeeAmountExtension {
+    pub withheld_amount: U64,
+}
+
+impl TransferFeeAmountExtension {
+    pub const LEN: usize = core::mem::size_of::<TransferFeeAmountExtension>();
+}
+
+impl sealed::Sealed for TransferFeeAmountExtension {}
+
+// SAFETY: `TransferFeeAmountExtension` is repr(C), contains only a
+// `U64` (repr(transparent) over `[u8; 8]`), has no padding, and all bit
+// patterns are valid.
+unsafe impl ExtensionValue for TransferFeeAmountExtension {
+    const TYPE: ExtensionType = ExtensionType::TransferFeeAmount;
+}


### PR DESCRIPTION
Pulling out just the specific extension structs added to https://github.com/anza-xyz/pinocchio/pull/415. This multi-part PR series is to help p-ATA calculate token 2022 account lengths https://github.com/solana-program/associated-token-account/pull/258.

This PR just focuses on adding the ATA-relevant extension structs w/ length that can later be referenced.