### PR TITLE
fix(token-2022): use extension types for account sizing

### DIFF
--- a/programs/token-2022/src/instructions/get_account_data_size.rs
+++ b/programs/token-2022/src/instructions/get_account_data_size.rs
@@ -1,6 +1,10 @@
 use {
     crate::{
-        instructions::{ExtensionDiscriminator, MAX_EXTENSION_COUNT},
+        instructions::{
+            write_extension_types_instruction_data, EXTENSION_TYPES_INSTRUCTION_DATA_LEN,
+            MAX_EXTENSION_COUNT,
+        },
+        state::ExtensionType,
         UNINIT_BYTE,
     },
     core::slice::from_raw_parts,
@@ -24,7 +28,7 @@ pub struct GetAccountDataSize<'a, 'b, 'c> {
     pub mint: &'a AccountView,
 
     /// New extension types to include in the reallocated account
-    pub extensions: &'c [ExtensionDiscriminator],
+    pub extensions: &'c [ExtensionType],
 
     /// The token program.
     pub token_program: &'b Address,
@@ -44,23 +48,13 @@ impl GetAccountDataSize<'_, '_, '_> {
         // Instruction data.
 
         // 1 byte (discriminator) + 2 bytes per extension (extension type as `u16`)
-        let mut instruction_data = [UNINIT_BYTE; 1 + MAX_EXTENSION_COUNT * 2];
+        let mut instruction_data = [UNINIT_BYTE; EXTENSION_TYPES_INSTRUCTION_DATA_LEN];
 
-        instruction_data[0].write(Self::DISCRIMINATOR);
-
-        for (i, extension) in self.extensions.iter().enumerate() {
-            let offset = 1 + i * 2;
-            // SAFETY: `offset` and `offset + 1` are within bounds of `instruction_data`
-            // since `extensions.len() <= MAX_EXTENSION_COUNT`.
-            //
-            // Write the extension type as a little-endian `u16`.
-            unsafe {
-                instruction_data
-                    .get_unchecked_mut(offset)
-                    .write(*extension as u8);
-                instruction_data.get_unchecked_mut(offset + 1).write(0);
-            }
-        }
+        write_extension_types_instruction_data(
+            &mut instruction_data,
+            Self::DISCRIMINATOR,
+            self.extensions,
+        );
 
         invoke(
             &InstructionView {

--- a/programs/token-2022/src/instructions/mod.rs
+++ b/programs/token-2022/src/instructions/mod.rs
@@ -1,3 +1,5 @@
+use {crate::state::ExtensionType, core::mem::MaybeUninit};
+
 mod amount_to_ui_amount;
 mod approve;
 mod approve_checked;
@@ -43,3 +45,109 @@ pub use {
 
 /// The maximum number of available extensions.
 const MAX_EXTENSION_COUNT: usize = 28;
+const EXTENSION_TYPES_INSTRUCTION_DATA_LEN: usize = 1 + MAX_EXTENSION_COUNT * 2;
+
+#[inline(always)]
+fn write_extension_types_instruction_data(
+    instruction_data: &mut [MaybeUninit<u8>; EXTENSION_TYPES_INSTRUCTION_DATA_LEN],
+    discriminator: u8,
+    extensions: &[ExtensionType],
+) {
+    debug_assert!(extensions.len() <= MAX_EXTENSION_COUNT);
+
+    instruction_data[0].write(discriminator);
+
+    for (i, extension) in extensions.iter().enumerate() {
+        let offset = 1 + i * 2;
+        let extension_type = (*extension as u16).to_le_bytes();
+        // SAFETY: `offset` and `offset + 1` are within bounds of
+        // `instruction_data` because the buffer is exactly
+        // `1 + MAX_EXTENSION_COUNT * 2` bytes and callers reject
+        // `extensions.len() > MAX_EXTENSION_COUNT`.
+        unsafe {
+            instruction_data
+                .get_unchecked_mut(offset)
+                .write(extension_type[0]);
+            instruction_data
+                .get_unchecked_mut(offset + 1)
+                .write(extension_type[1]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{state::ExtensionType, UNINIT_BYTE},
+    };
+
+    #[test]
+    fn write_extension_types_instruction_data_with_empty_extensions() {
+        let mut instruction_data = [UNINIT_BYTE; EXTENSION_TYPES_INSTRUCTION_DATA_LEN];
+
+        write_extension_types_instruction_data(&mut instruction_data, 21, &[]);
+
+        // SAFETY: the helper initialized the single discriminator byte.
+        let bytes =
+            unsafe { core::slice::from_raw_parts(instruction_data.as_ptr().cast::<u8>(), 1) };
+
+        assert_eq!(bytes, &[21]);
+    }
+
+    #[test]
+    fn write_extension_types_instruction_data_at_max_extension_count() {
+        const EXTENSIONS: [ExtensionType; MAX_EXTENSION_COUNT] = [
+            ExtensionType::TransferFeeConfig,
+            ExtensionType::TransferFeeAmount,
+            ExtensionType::MintCloseAuthority,
+            ExtensionType::ConfidentialTransferMint,
+            ExtensionType::ConfidentialTransferAccount,
+            ExtensionType::DefaultAccountState,
+            ExtensionType::ImmutableOwner,
+            ExtensionType::MemoTransfer,
+            ExtensionType::NonTransferable,
+            ExtensionType::InterestBearingConfig,
+            ExtensionType::CpiGuard,
+            ExtensionType::PermanentDelegate,
+            ExtensionType::NonTransferableAccount,
+            ExtensionType::TransferHook,
+            ExtensionType::TransferHookAccount,
+            ExtensionType::ConfidentialTransferFeeConfig,
+            ExtensionType::ConfidentialTransferFeeAmount,
+            ExtensionType::MetadataPointer,
+            ExtensionType::TokenMetadata,
+            ExtensionType::GroupPointer,
+            ExtensionType::TokenGroup,
+            ExtensionType::GroupMemberPointer,
+            ExtensionType::TokenGroupMember,
+            ExtensionType::ConfidentialMintBurn,
+            ExtensionType::ScaledUiAmount,
+            ExtensionType::Pausable,
+            ExtensionType::PausableAccount,
+            ExtensionType::PermissionedBurn,
+        ];
+
+        let mut instruction_data = [UNINIT_BYTE; EXTENSION_TYPES_INSTRUCTION_DATA_LEN];
+
+        write_extension_types_instruction_data(&mut instruction_data, 21, &EXTENSIONS);
+
+        // SAFETY: the helper initialized all `1 + MAX_EXTENSION_COUNT * 2` bytes.
+        let bytes = unsafe {
+            core::slice::from_raw_parts(
+                instruction_data.as_ptr().cast::<u8>(),
+                instruction_data.len(),
+            )
+        };
+
+        #[rustfmt::skip]
+        let expected: [u8; EXTENSION_TYPES_INSTRUCTION_DATA_LEN] = [
+            21,
+            1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0, 10, 0,
+            11, 0, 12, 0, 13, 0, 14, 0, 15, 0, 16, 0, 17, 0, 18, 0, 19, 0, 20, 0,
+            21, 0, 22, 0, 23, 0, 24, 0, 25, 0, 26, 0, 27, 0, 28, 0,
+        ];
+
+        assert_eq!(bytes, &expected);
+    }
+}

--- a/programs/token-2022/src/instructions/reallocate.rs
+++ b/programs/token-2022/src/instructions/reallocate.rs
@@ -1,6 +1,10 @@
 use {
     crate::{
-        instructions::{ExtensionDiscriminator, MAX_EXTENSION_COUNT, MAX_MULTISIG_SIGNERS},
+        instructions::{
+            write_extension_types_instruction_data, EXTENSION_TYPES_INSTRUCTION_DATA_LEN,
+            MAX_EXTENSION_COUNT, MAX_MULTISIG_SIGNERS,
+        },
+        state::ExtensionType,
         UNINIT_BYTE,
     },
     core::{mem::MaybeUninit, slice::from_raw_parts},
@@ -48,7 +52,7 @@ pub struct Reallocate<'a, 'b, 'c, 'd, MultisigSigner: AsRef<AccountView>> {
     pub multisig_signers: &'c [MultisigSigner],
 
     /// New extension types to include in the reallocated account
-    pub extensions: &'d [ExtensionDiscriminator],
+    pub extensions: &'d [ExtensionType],
 
     /// The token program.
     pub token_program: &'b Address,
@@ -68,7 +72,7 @@ impl<'a, 'b, 'c, 'd, MultisigSigner: AsRef<AccountView>>
         payer: &'a AccountView,
         system_program: &'a AccountView,
         owner: &'a AccountView,
-        extensions: &'d [ExtensionDiscriminator],
+        extensions: &'d [ExtensionType],
     ) -> Self {
         Self::with_multisig_signers(
             token_program,
@@ -90,7 +94,7 @@ impl<'a, 'b, 'c, 'd, MultisigSigner: AsRef<AccountView>>
         payer: &'a AccountView,
         system_program: &'a AccountView,
         owner: &'a AccountView,
-        extensions: &'d [ExtensionDiscriminator],
+        extensions: &'d [ExtensionType],
         multisig_signers: &'c [MultisigSigner],
     ) -> Self {
         Self {
@@ -170,23 +174,13 @@ impl<'a, 'b, 'c, 'd, MultisigSigner: AsRef<AccountView>>
         let expected_data = 1 + self.extensions.len() * 2;
 
         // 1 byte (discriminator) + 2 bytes per extension (extension type as `u16`).
-        let mut instruction_data = [UNINIT_BYTE; 1 + MAX_EXTENSION_COUNT * 2];
+        let mut instruction_data = [UNINIT_BYTE; EXTENSION_TYPES_INSTRUCTION_DATA_LEN];
 
-        instruction_data[0].write(Self::DISCRIMINATOR);
-
-        for (i, extension) in self.extensions.iter().enumerate() {
-            let offset = 1 + i * 2;
-            // SAFETY: `offset` and `offset + 1` are within bounds of `instruction_data`
-            // since `extensions.len() <= MAX_EXTENSION_COUNT`.
-            //
-            // Write the extension type as a little-endian `u16`.
-            unsafe {
-                instruction_data
-                    .get_unchecked_mut(offset)
-                    .write(*extension as u8);
-                instruction_data.get_unchecked_mut(offset + 1).write(0);
-            }
-        }
+        write_extension_types_instruction_data(
+            &mut instruction_data,
+            Self::DISCRIMINATOR,
+            self.extensions,
+        );
 
         invoke_signed_with_bounds::<{ 4 + MAX_MULTISIG_SIGNERS }, _>(
             &InstructionView {


### PR DESCRIPTION
## Summary
- Switch GetAccountDataSize to accept Token-2022 ExtensionType values instead of instruction ExtensionDiscriminator values.
- Apply the same ExtensionType API to Reallocate, which serializes the same extension list format.
- Share little-endian u16 extension-list encoding and cover it with focused unit tests.

## Testing
- cargo test -p pinocchio-token-2022
- pnpm cargo-audit
- pnpm miri
- pnpm format/clippy/doc/hack/build-sbf/test for all Main workflow matrix members
