### PR TITLE
feat(token-2022): add fixed-size POD extension states

### DIFF
--- a/programs/token-2022/src/state/extension/cpi_guard.rs
+++ b/programs/token-2022/src/state/extension/cpi_guard.rs
@@ -1,0 +1,27 @@
+use {
+    super::{sealed, ExtensionType, ExtensionValue},
+    solana_zero_copy::unaligned::Bool,
+};
+
+/// CPI guard extension data for token accounts (1 byte).
+///
+/// When enabled, privileged token operations on this account are blocked from
+/// executing via cross-program invocation.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct CpiGuardExtension {
+    pub lock_cpi: Bool,
+}
+
+impl CpiGuardExtension {
+    pub const LEN: usize = core::mem::size_of::<CpiGuardExtension>();
+}
+
+impl sealed::Sealed for CpiGuardExtension {}
+
+// SAFETY: `CpiGuardExtension` is repr(C), contains only a `Bool`
+// (repr(transparent) over `u8`), has no padding, and all bit patterns are
+// valid.
+unsafe impl ExtensionValue for CpiGuardExtension {
+    const TYPE: ExtensionType = ExtensionType::CpiGuard;
+}

--- a/programs/token-2022/src/state/extension/group_member_pointer.rs
+++ b/programs/token-2022/src/state/extension/group_member_pointer.rs
@@ -1,0 +1,29 @@
+use {
+    super::{sealed, ExtensionType, ExtensionValue},
+    solana_address::Address,
+    solana_nullable::MaybeNull,
+};
+
+/// Group member pointer extension data for mints (64 bytes).
+///
+/// Points to the account that holds the mint's token group member
+/// configuration and names the authority permitted to update that pointer.
+#[repr(C)]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct GroupMemberPointerExtension {
+    pub authority: MaybeNull<Address>,
+    pub member_address: MaybeNull<Address>,
+}
+
+impl GroupMemberPointerExtension {
+    pub const LEN: usize = core::mem::size_of::<GroupMemberPointerExtension>();
+}
+
+impl sealed::Sealed for GroupMemberPointerExtension {}
+
+// SAFETY: `GroupMemberPointerExtension` is repr(C), contains only
+// `MaybeNull<Address>` fields which are repr(transparent) over `Address`
+// (`[u8; 32]`), has no padding, and all bit patterns are valid.
+unsafe impl ExtensionValue for GroupMemberPointerExtension {
+    const TYPE: ExtensionType = ExtensionType::GroupMemberPointer;
+}

--- a/programs/token-2022/src/state/extension/group_pointer.rs
+++ b/programs/token-2022/src/state/extension/group_pointer.rs
@@ -1,0 +1,29 @@
+use {
+    super::{sealed, ExtensionType, ExtensionValue},
+    solana_address::Address,
+    solana_nullable::MaybeNull,
+};
+
+/// Group pointer extension data for mints (64 bytes).
+///
+/// Points to the account that holds the mint's token group configuration and
+/// names the authority permitted to update that pointer.
+#[repr(C)]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct GroupPointerExtension {
+    pub authority: MaybeNull<Address>,
+    pub group_address: MaybeNull<Address>,
+}
+
+impl GroupPointerExtension {
+    pub const LEN: usize = core::mem::size_of::<GroupPointerExtension>();
+}
+
+impl sealed::Sealed for GroupPointerExtension {}
+
+// SAFETY: `GroupPointerExtension` is repr(C), contains only
+// `MaybeNull<Address>` fields which are repr(transparent) over `Address`
+// (`[u8; 32]`), has no padding, and all bit patterns are valid.
+unsafe impl ExtensionValue for GroupPointerExtension {
+    const TYPE: ExtensionType = ExtensionType::GroupPointer;
+}

--- a/programs/token-2022/src/state/extension/memo_transfer.rs
+++ b/programs/token-2022/src/state/extension/memo_transfer.rs
@@ -1,0 +1,27 @@
+use {
+    super::{sealed, ExtensionType, ExtensionValue},
+    solana_zero_copy::unaligned::Bool,
+};
+
+/// Memo transfer extension data for token accounts (1 byte).
+///
+/// When enabled, transfers into this account must be accompanied by a memo
+/// instruction.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct MemoTransferExtension {
+    pub require_incoming_transfer_memos: Bool,
+}
+
+impl MemoTransferExtension {
+    pub const LEN: usize = core::mem::size_of::<MemoTransferExtension>();
+}
+
+impl sealed::Sealed for MemoTransferExtension {}
+
+// SAFETY: `MemoTransferExtension` is repr(C), contains only a `Bool`
+// (repr(transparent) over `u8`), has no padding, and all bit patterns are
+// valid.
+unsafe impl ExtensionValue for MemoTransferExtension {
+    const TYPE: ExtensionType = ExtensionType::MemoTransfer;
+}

--- a/programs/token-2022/src/state/extension/metadata_pointer.rs
+++ b/programs/token-2022/src/state/extension/metadata_pointer.rs
@@ -1,0 +1,29 @@
+use {
+    super::{sealed, ExtensionType, ExtensionValue},
+    solana_address::Address,
+    solana_nullable::MaybeNull,
+};
+
+/// Metadata pointer extension data for mints (64 bytes).
+///
+/// Points to the account that holds the mint's token metadata and names the
+/// authority permitted to update that pointer.
+#[repr(C)]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct MetadataPointerExtension {
+    pub authority: MaybeNull<Address>,
+    pub metadata_address: MaybeNull<Address>,
+}
+
+impl MetadataPointerExtension {
+    pub const LEN: usize = core::mem::size_of::<MetadataPointerExtension>();
+}
+
+impl sealed::Sealed for MetadataPointerExtension {}
+
+// SAFETY: `MetadataPointerExtension` is repr(C), contains only
+// `MaybeNull<Address>` fields which are repr(transparent) over `Address`
+// (`[u8; 32]`), has no padding, and all bit patterns are valid.
+unsafe impl ExtensionValue for MetadataPointerExtension {
+    const TYPE: ExtensionType = ExtensionType::MetadataPointer;
+}

--- a/programs/token-2022/src/state/extension/mint_close_authority.rs
+++ b/programs/token-2022/src/state/extension/mint_close_authority.rs
@@ -1,0 +1,28 @@
+use {
+    super::{sealed, ExtensionType, ExtensionValue},
+    solana_address::Address,
+    solana_nullable::MaybeNull,
+};
+
+/// Mint close authority extension data for mints (32 bytes).
+///
+/// When set on a mint, the authority is permitted to close the mint account
+/// once its supply is zero.
+#[repr(C)]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct MintCloseAuthorityExtension {
+    pub close_authority: MaybeNull<Address>,
+}
+
+impl MintCloseAuthorityExtension {
+    pub const LEN: usize = core::mem::size_of::<MintCloseAuthorityExtension>();
+}
+
+impl sealed::Sealed for MintCloseAuthorityExtension {}
+
+// SAFETY: `MintCloseAuthorityExtension` is repr(C), contains only
+// `MaybeNull<Address>` which is repr(transparent) over `Address` (`[u8; 32]`),
+// has no padding, and all bit patterns are valid.
+unsafe impl ExtensionValue for MintCloseAuthorityExtension {
+    const TYPE: ExtensionType = ExtensionType::MintCloseAuthority;
+}

--- a/programs/token-2022/src/state/extension/mod.rs
+++ b/programs/token-2022/src/state/extension/mod.rs
@@ -1,6 +1,14 @@
+pub mod cpi_guard;
 pub mod default_account_state;
+pub mod group_member_pointer;
+pub mod group_pointer;
 pub mod immutable_owner;
+pub mod memo_transfer;
+pub mod metadata_pointer;
+pub mod mint_close_authority;
+pub mod non_transferable;
 pub mod non_transferable_account;
+pub mod pausable;
 pub mod pausable_account;
 pub mod permanent_delegate;
 pub mod permissioned_burn;
@@ -14,9 +22,17 @@ use {
     solana_program_error::ProgramError,
 };
 pub use {
+    cpi_guard::CpiGuardExtension,
     default_account_state::DefaultAccountStateExtension,
+    group_member_pointer::GroupMemberPointerExtension,
+    group_pointer::GroupPointerExtension,
     immutable_owner::ImmutableOwnerExtension,
+    memo_transfer::MemoTransferExtension,
+    metadata_pointer::MetadataPointerExtension,
+    mint_close_authority::MintCloseAuthorityExtension,
+    non_transferable::NonTransferableExtension,
     non_transferable_account::NonTransferableAccountExtension,
+    pausable::PausableExtension,
     pausable_account::PausableAccountExtension,
     permanent_delegate::PermanentDelegateExtension,
     permissioned_burn::PermissionedBurnExtension,
@@ -265,6 +281,14 @@ pub const fn extension_value_len(extension_type: ExtensionType) -> Option<usize>
         ExtensionType::NonTransferableAccount => Some(NonTransferableAccountExtension::LEN),
         ExtensionType::PausableAccount => Some(PausableAccountExtension::LEN),
         ExtensionType::TransferFeeAmount => Some(TransferFeeAmountExtension::LEN),
+        ExtensionType::MintCloseAuthority => Some(MintCloseAuthorityExtension::LEN),
+        ExtensionType::NonTransferable => Some(NonTransferableExtension::LEN),
+        ExtensionType::MemoTransfer => Some(MemoTransferExtension::LEN),
+        ExtensionType::CpiGuard => Some(CpiGuardExtension::LEN),
+        ExtensionType::MetadataPointer => Some(MetadataPointerExtension::LEN),
+        ExtensionType::GroupPointer => Some(GroupPointerExtension::LEN),
+        ExtensionType::GroupMemberPointer => Some(GroupMemberPointerExtension::LEN),
+        ExtensionType::Pausable => Some(PausableExtension::LEN),
         _ => None,
     }
 }

--- a/programs/token-2022/src/state/extension/non_transferable.rs
+++ b/programs/token-2022/src/state/extension/non_transferable.rs
@@ -1,0 +1,21 @@
+use super::{sealed, ExtensionType, ExtensionValue};
+
+/// Non-transferable extension (marker, 0 bytes).
+///
+/// When set on a mint, tokens for the mint cannot be transferred between
+/// accounts.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct NonTransferableExtension;
+
+impl NonTransferableExtension {
+    pub const LEN: usize = core::mem::size_of::<NonTransferableExtension>();
+}
+
+impl sealed::Sealed for NonTransferableExtension {}
+
+// SAFETY: `NonTransferableExtension` is a zero-sized type with no
+// representation requirements.
+unsafe impl ExtensionValue for NonTransferableExtension {
+    const TYPE: ExtensionType = ExtensionType::NonTransferable;
+}

--- a/programs/token-2022/src/state/extension/pausable.rs
+++ b/programs/token-2022/src/state/extension/pausable.rs
@@ -1,0 +1,31 @@
+use {
+    super::{sealed, ExtensionType, ExtensionValue},
+    solana_address::Address,
+    solana_nullable::MaybeNull,
+    solana_zero_copy::unaligned::Bool,
+};
+
+/// Pausable extension data for mints (33 bytes).
+///
+/// When set on a mint, the authority can pause and resume minting,
+/// transferring, and burning of tokens for the mint.
+#[repr(C)]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PausableExtension {
+    pub authority: MaybeNull<Address>,
+    pub paused: Bool,
+}
+
+impl PausableExtension {
+    pub const LEN: usize = core::mem::size_of::<PausableExtension>();
+}
+
+impl sealed::Sealed for PausableExtension {}
+
+// SAFETY: `PausableExtension` is repr(C), contains a `MaybeNull<Address>`
+// (repr(transparent) over `[u8; 32]`) followed by a `Bool`
+// (repr(transparent) over `u8`), has no padding, and all bit patterns are
+// valid.
+unsafe impl ExtensionValue for PausableExtension {
+    const TYPE: ExtensionType = ExtensionType::Pausable;
+}

--- a/programs/token-2022/src/state/extension/state.rs
+++ b/programs/token-2022/src/state/extension/state.rs
@@ -439,8 +439,10 @@ mod tests {
                 transfer_hook_account::TransferHookAccountExtension, try_calculate_account_len,
                 TokenError, ACCOUNT_TYPE_INDEX, EXTENSION_NOT_FOUND_ERROR_CODE,
             },
-            AccountState, ImmutableOwnerExtension, NonTransferableAccountExtension,
-            PausableAccountExtension, TransferFeeAmountExtension,
+            AccountState, CpiGuardExtension, GroupMemberPointerExtension, GroupPointerExtension,
+            ImmutableOwnerExtension, MemoTransferExtension, MetadataPointerExtension,
+            MintCloseAuthorityExtension, NonTransferableAccountExtension, NonTransferableExtension,
+            PausableAccountExtension, PausableExtension, TransferFeeAmountExtension,
         },
         core::{mem::size_of, ptr::copy_nonoverlapping},
         solana_account_view::{RuntimeAccount, NOT_BORROWED},
@@ -1382,5 +1384,109 @@ mod tests {
 
         let account = StateWithExtensions::<Account>::from_bytes(&data).unwrap();
         account.get_extension::<PausableAccountExtension>().unwrap();
+    }
+
+    #[test]
+    fn mint_close_authority_extension_read_roundtrip() {
+        let value = [13u8; 32];
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(&mut tlv_data, ExtensionType::MintCloseAuthority, &value);
+        let data = build_mint_data(&tlv_data);
+
+        let mint = StateWithExtensions::<Mint>::from_bytes(&data).unwrap();
+        let ext = mint.get_extension::<MintCloseAuthorityExtension>().unwrap();
+        assert_eq!(ext.close_authority.as_ref().unwrap().as_ref(), &[13u8; 32]);
+    }
+
+    #[test]
+    fn non_transferable_extension_present() {
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(&mut tlv_data, ExtensionType::NonTransferable, &[]);
+        let data = build_mint_data(&tlv_data);
+
+        let mint = StateWithExtensions::<Mint>::from_bytes(&data).unwrap();
+        mint.get_extension::<NonTransferableExtension>().unwrap();
+    }
+
+    #[test]
+    fn memo_transfer_extension_read_roundtrip() {
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(&mut tlv_data, ExtensionType::MemoTransfer, &[1u8]);
+        let data = build_token_data(&tlv_data);
+
+        let account = StateWithExtensions::<Account>::from_bytes(&data).unwrap();
+        let ext = account.get_extension::<MemoTransferExtension>().unwrap();
+        assert!(bool::from(ext.require_incoming_transfer_memos));
+    }
+
+    #[test]
+    fn cpi_guard_extension_read_roundtrip() {
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(&mut tlv_data, ExtensionType::CpiGuard, &[1u8]);
+        let data = build_token_data(&tlv_data);
+
+        let account = StateWithExtensions::<Account>::from_bytes(&data).unwrap();
+        let ext = account.get_extension::<CpiGuardExtension>().unwrap();
+        assert!(bool::from(ext.lock_cpi));
+    }
+
+    #[test]
+    fn metadata_pointer_extension_read_roundtrip() {
+        let mut value = [0u8; 64];
+        value[..32].copy_from_slice(&[11u8; 32]);
+        value[32..64].copy_from_slice(&[22u8; 32]);
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(&mut tlv_data, ExtensionType::MetadataPointer, &value);
+        let data = build_mint_data(&tlv_data);
+
+        let mint = StateWithExtensions::<Mint>::from_bytes(&data).unwrap();
+        let ext = mint.get_extension::<MetadataPointerExtension>().unwrap();
+        assert_eq!(ext.authority.as_ref().unwrap().as_ref(), &[11u8; 32]);
+        assert_eq!(ext.metadata_address.as_ref().unwrap().as_ref(), &[22u8; 32]);
+    }
+
+    #[test]
+    fn group_pointer_extension_read_roundtrip() {
+        let mut value = [0u8; 64];
+        value[..32].copy_from_slice(&[33u8; 32]);
+        value[32..64].copy_from_slice(&[44u8; 32]);
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(&mut tlv_data, ExtensionType::GroupPointer, &value);
+        let data = build_mint_data(&tlv_data);
+
+        let mint = StateWithExtensions::<Mint>::from_bytes(&data).unwrap();
+        let ext = mint.get_extension::<GroupPointerExtension>().unwrap();
+        assert_eq!(ext.authority.as_ref().unwrap().as_ref(), &[33u8; 32]);
+        assert_eq!(ext.group_address.as_ref().unwrap().as_ref(), &[44u8; 32]);
+    }
+
+    #[test]
+    fn group_member_pointer_extension_read_roundtrip() {
+        let mut value = [0u8; 64];
+        value[..32].copy_from_slice(&[55u8; 32]);
+        value[32..64].copy_from_slice(&[66u8; 32]);
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(&mut tlv_data, ExtensionType::GroupMemberPointer, &value);
+        let data = build_mint_data(&tlv_data);
+
+        let mint = StateWithExtensions::<Mint>::from_bytes(&data).unwrap();
+        let ext = mint.get_extension::<GroupMemberPointerExtension>().unwrap();
+        assert_eq!(ext.authority.as_ref().unwrap().as_ref(), &[55u8; 32]);
+        assert_eq!(ext.member_address.as_ref().unwrap().as_ref(), &[66u8; 32]);
+    }
+
+    #[test]
+    fn pausable_extension_read_roundtrip() {
+        let mut value = [0u8; 33];
+        value[..32].copy_from_slice(&[77u8; 32]);
+        value[32] = 1;
+        let mut tlv_data = Vec::new();
+        push_tlv_entry(&mut tlv_data, ExtensionType::Pausable, &value);
+        let data = build_mint_data(&tlv_data);
+
+        let mint = StateWithExtensions::<Mint>::from_bytes(&data).unwrap();
+        let ext = mint.get_extension::<PausableExtension>().unwrap();
+        assert_eq!(ext.authority.as_ref().unwrap().as_ref(), &[77u8; 32]);
+        assert!(bool::from(ext.paused));
     }
 }


### PR DESCRIPTION
## Summary

Adds typed TLV extension state for the remaining **fixed-size POD** token-2022 extensions. Each layout is verified byte-for-byte against `spl-token-2022-interface` v3.0.0 (same `MaybeNull<Address>` / `Bool` primitives already used in this crate).

### Mint extensions
| Extension | id | Fields | Size |
|-----------|-----|--------|------|
| `MintCloseAuthorityExtension` | 3 | `close_authority: MaybeNull<Address>` | 32 |
| `NonTransferableExtension` | 9 | marker | 0 |
| `MetadataPointerExtension` | 18 | `authority`, `metadata_address` | 64 |
| `GroupPointerExtension` | 20 | `authority`, `group_address` | 64 |
| `GroupMemberPointerExtension` | 22 | `authority`, `member_address` | 64 |
| `PausableExtension` | 26 | `authority`, `paused: Bool` | 33 |

### Account extensions
| Extension | id | Fields | Size |
|-----------|-----|--------|------|
| `MemoTransferExtension` | 8 | `require_incoming_transfer_memos: Bool` | 1 |
| `CpiGuardExtension` | 11 | `lock_cpi: Bool` | 1 |

All 8 are registered in `extension_value_len` and re-exported from `state::extension`. Follows the existing extension file conventions (`#[repr(C)]`, `LEN`, `sealed::Sealed`, `unsafe impl ExtensionValue` + `SAFETY:` justification).

Pointer extensions store only the pointer (authority + address); the data they reference (`TokenMetadata`/`TokenGroup`/`TokenGroupMember`) lives in separate extensions and is out of scope here.

## Test plan
- `cargo test -p pinocchio-token-2022` — 66 pass (8 new read-roundtrip tests)
- `cargo clippy -p pinocchio-token-2022 --all-targets` — clean
- `cargo +nightly fmt --check` — clean

## Follow-ups (not in this PR)
Fixed-POD multi-field (`TransferFeeConfig`, `InterestBearingConfig`, `TokenGroup`, `TokenGroupMember`), `ScaledUiAmount` (needs an f64 POD), variable-length `TokenMetadata`, and the confidential-transfer family.