### PR TITLE
Bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "pinocchio"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "pinocchio",
  "solana-account-view",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pinocchio"
 description = "Create Solana programs with no external dependencies attached"
-version = "0.11.1"
+version = "0.11.2"
 edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"


### PR DESCRIPTION
### Problem

The publishing of version `0.11.2` [failed](https://github.com/anza-xyz/pinocchio/actions/runs/27215490365/job/80355941992) to bump the version on `Cargo.toml`.

### Solution

Update the version on `Cargo.toml`.