### PR TITLE
Use align_pointer in the lazy entrypoint

### DIFF
--- a/sdk/src/entrypoint/lazy.rs
+++ b/sdk/src/entrypoint/lazy.rs
@@ -8,7 +8,7 @@ use {
         error::ProgramError,
         Address, BPF_ALIGN_OF_U128,
     },
-    core::mem::size_of,
+    core::{mem::size_of, ptr::with_exposed_provenance_mut},
 };
 
 /// Declare the lazy program entrypoint.
@@ -256,7 +256,7 @@ impl InstructionContext {
 
             self.buffer = self.buffer.add(STATIC_ACCOUNT_DATA);
             self.buffer = self.buffer.add((*account).data_len as usize);
-            self.buffer = self.buffer.add(self.buffer.align_offset(BPF_ALIGN_OF_U128));
+            self.buffer = align_pointer!(self.buffer);
 
             MaybeAccount::Account(AccountView::new_unchecked(account))
         } else {

--- a/sdk/src/entrypoint/mod.rs
+++ b/sdk/src/entrypoint/mod.rs
@@ -57,6 +57,20 @@
 //! └─ 32 bytes: address of the program account
 //! ```
 
+/// Align a pointer to the BPF alignment of [`u128`].
+macro_rules! align_pointer {
+    ($ptr:expr) => {
+        // Integer-to-pointer cast: first compute the aligned address as a `usize`,
+        // since this is more CU-efficient than using `ptr::align_offset()` or the
+        // strict provenance API (e.g., `ptr::with_addr()`). Then cast the result
+        // back to a pointer. The resulting pointer is guaranteed to be valid
+        // because it follows the layout serialized by the runtime.
+        with_exposed_provenance_mut(
+            ($ptr.expose_provenance() + (BPF_ALIGN_OF_U128 - 1)) & !(BPF_ALIGN_OF_U128 - 1),
+        )
+    };
+}
+
 pub mod lazy;
 
 #[cfg(feature = "alloc")]
@@ -275,20 +289,6 @@ pub unsafe fn process_entrypoint<const MAX_ACCOUNTS: usize>(
         Ok(()) => SUCCESS,
         Err(e) => program_error_to_u64(e),
     }
-}
-
-/// Align a pointer to the BPF alignment of [`u128`].
-macro_rules! align_pointer {
-    ($ptr:ident) => {
-        // Integer-to-pointer cast: first compute the aligned address as a `usize`,
-        // since this is more CU-efficient than using `ptr::align_offset()` or the
-        // strict provenance API (e.g., `ptr::with_addr()`). Then cast the result
-        // back to a pointer. The resulting pointer is guaranteed to be valid
-        // because it follows the layout serialized by the runtime.
-        with_exposed_provenance_mut(
-            ($ptr.expose_provenance() + (BPF_ALIGN_OF_U128 - 1)) & !(BPF_ALIGN_OF_U128 - 1),
-        )
-    };
 }
 
 /// Advance the input pointer in relation to a non-duplicated account.


### PR DESCRIPTION
`InstructionContext::read_account` aligned the input buffer with `align_offset`, which is less CU-efficient than the bitwise arithmetic in `align_pointer!` and may return `usize::MAX` when the alignment cannot be determined. The macro was defined below `pub mod lazy;` so it was not in scope there.

Moved the macro above the module declaration and used it in `read_account`. The macro now takes `$ptr:expr` so it works on field accesses like `self.buffer`; the existing call sites are unchanged.

Verified with cargo test, miri, clippy, and build-sbf.

Fixes #426