### PR TITLE
Relax workspace dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/anza-xyz/pinocchio"
 rust-version = "1.89.0"
 
 [workspace.dependencies]
-pinocchio = { version = "0.11", default-features = false, path = "sdk" }
+pinocchio = { path = "sdk", default-features = false }
 solana-account-view = "2.0"
 solana-address = "2.0"
 solana-define-syscall = "5.0"


### PR DESCRIPTION
### Problem

Currently the workspace dependency for pinocchio specify a version. This creates problems when trying to publish `alpha`, `beta` or `rc` versions, since these need to be specified explicitly.
```
Upgrading pinocchio from 0.11.2 to 0.11.3-rc.1
error: `cargo metadata` exited with an error: failed to select a version for the requirement `pinocchio = "^0.11"`
       candidate versions found which didn't match: 0.11.3-rc.1
       location searched: /home/runner/work/pinocchio/pinocchio/sdk
       required by package `pinocchio-system v0.6.1 (/home/runner/work/pinocchio/pinocchio/programs/system)`
       if you are looking for the prerelease package it needs to be specified explicitly
           pinocchio = { version = "0.11.3-rc.1" }
```

### Solution

Remove the version from the workspace dependency so the current version of the crate is used.