### PR TITLE
programs/token: Rename generic trait

### DIFF
--- a/programs/token-2022/src/instructions/get_account_data_size.rs
+++ b/programs/token-2022/src/instructions/get_account_data_size.rs
@@ -97,7 +97,7 @@ impl<'account, 'extensions, Program: TokenInterface>
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token-2022/src/instructions/get_account_data_size.rs
+++ b/programs/token-2022/src/instructions/get_account_data_size.rs
@@ -10,7 +10,7 @@ use {
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     pinocchio_token::{
         instructions::{batch::Batch, CpiWriter},
-        TokenProgram,
+        TokenInterface,
     },
     solana_account_view::AccountView,
     solana_address::Address,
@@ -41,7 +41,7 @@ const MAX_DATA_LEN: usize = EXTENSION_TYPES_INSTRUCTION_DATA_LEN;
 /// Accounts expected by this instruction:
 ///
 ///   0. `[]` The mint to calculate for.
-pub struct GetAccountDataSize<'account, 'extensions, Program: TokenProgram> {
+pub struct GetAccountDataSize<'account, 'extensions, Program: TokenInterface> {
     /// The mint to calculate for.
     pub mint: &'account AccountView,
 
@@ -52,7 +52,7 @@ pub struct GetAccountDataSize<'account, 'extensions, Program: TokenProgram> {
     _program: PhantomData<Program>,
 }
 
-impl<'account, 'extensions, Program: TokenProgram>
+impl<'account, 'extensions, Program: TokenInterface>
     GetAccountDataSize<'account, 'extensions, Program>
 {
     /// The instruction discriminator.
@@ -130,7 +130,7 @@ impl<'account, 'extensions, Program: TokenProgram>
     }
 }
 
-impl<Program: TokenProgram> CpiWriter for GetAccountDataSize<'_, '_, Program> {
+impl<Program: TokenInterface> CpiWriter for GetAccountDataSize<'_, '_, Program> {
     #[inline(always)]
     fn write_accounts<'cpi>(
         &self,
@@ -159,7 +159,7 @@ impl<Program: TokenProgram> CpiWriter for GetAccountDataSize<'_, '_, Program> {
     }
 }
 
-impl<Program: TokenProgram> super::IntoBatch<Program> for GetAccountDataSize<'_, '_, Program> {
+impl<Program: TokenInterface> super::IntoBatch<Program> for GetAccountDataSize<'_, '_, Program> {
     #[inline(always)]
     fn into_batch<'account, 'state>(
         self,

--- a/programs/token-2022/src/instructions/mod.rs
+++ b/programs/token-2022/src/instructions/mod.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{state::ExtensionType, Program2022},
+    crate::{state::ExtensionType, Token2022Program},
     core::mem::MaybeUninit,
     solana_program_error::ProgramError,
 };
@@ -48,7 +48,10 @@ const EXTENSION_TYPES_INSTRUCTION_DATA_LEN: usize = 1 + MAX_EXTENSION_COUNT * 2;
 ///
 ///   0. `[]` The mint to calculate for.
 pub type AmountToUiAmount<'account> =
-    pinocchio_token::instructions::amount_to_ui_amount::AmountToUiAmount<'account, Program2022>;
+    pinocchio_token::instructions::amount_to_ui_amount::AmountToUiAmount<
+        'account,
+        Token2022Program,
+    >;
 
 /// Approves a delegate. A delegate is given the authority over tokens on
 /// behalf of the source account's owner.
@@ -70,7 +73,7 @@ pub type Approve<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Approves a delegate. A delegate is given the authority over tokens on
@@ -99,18 +102,18 @@ pub type ApproveChecked<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// A collection of instructions that can be serialized into a token `Batch`
 /// instruction.
 pub type Batch<'account, 'state> =
-    pinocchio_token::instructions::batch::Batch<'account, 'state, Program2022>;
+    pinocchio_token::instructions::batch::Batch<'account, 'state, Token2022Program>;
 
 #[cfg(feature = "alloc")]
 /// A state object that contains the buffers for a `Batch` instruction.
 pub type BatchState<'account> =
-    pinocchio_token::instructions::batch::BatchState<'account, Program2022>;
+    pinocchio_token::instructions::batch::BatchState<'account, Token2022Program>;
 
 /// Burns tokens by removing them from an account.  `Burn` does not support
 /// accounts associated with the native mint, use `CloseAccount` instead.
@@ -127,8 +130,12 @@ pub type BatchState<'account> =
 ///   1. `[writable]` The token mint.
 ///   2. `[]` The account's multisignature owner/delegate.
 ///   3. `..+M` `[signer]` M signer accounts.
-pub type Burn<'account, 'multisig, MultisigSigner> =
-    pinocchio_token::instructions::burn::Burn<'account, 'multisig, MultisigSigner, Program2022>;
+pub type Burn<'account, 'multisig, MultisigSigner> = pinocchio_token::instructions::burn::Burn<
+    'account,
+    'multisig,
+    MultisigSigner,
+    Token2022Program,
+>;
 
 /// Burns tokens by removing them from an account.
 /// [`BurnChecked`] does not support accounts
@@ -155,7 +162,7 @@ pub type BurnChecked<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Close an account by transferring all its SOL to the destination account.
@@ -178,7 +185,7 @@ pub type CloseAccount<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Freeze an Initialized account using the Mint's `freeze_authority` (if
@@ -201,7 +208,7 @@ pub type FreezeAccount<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Gets the required size of an account for the given mint as a
@@ -214,7 +221,7 @@ pub type FreezeAccount<'account, 'multisig, MultisigSigner> =
 ///
 ///   0. `[]` The mint to calculate for.
 pub type GetAccountDataSize<'account, 'extensions> =
-    get_account_data_size::GetAccountDataSize<'account, 'extensions, Program2022>;
+    get_account_data_size::GetAccountDataSize<'account, 'extensions, Token2022Program>;
 
 /// Initializes a new account to hold tokens. If this account is associated
 /// with the native mint then the token balance of the initialized account
@@ -235,7 +242,10 @@ pub type GetAccountDataSize<'account, 'extensions> =
 ///   2. `[]` The new account's owner/multisignature.
 ///   3. `[]` Rent sysvar.
 pub type InitializeAccount<'account> =
-    pinocchio_token::instructions::initialize_account::InitializeAccount<'account, Program2022>;
+    pinocchio_token::instructions::initialize_account::InitializeAccount<
+        'account,
+        Token2022Program,
+    >;
 
 /// Like [`InitializeAccount`], but the owner pubkey is
 /// passed via instruction data rather than the accounts list. This
@@ -249,7 +259,10 @@ pub type InitializeAccount<'account> =
 ///   1. `[]` The mint this account will be associated with.
 ///   2. `[]` Rent sysvar.
 pub type InitializeAccount2<'account> =
-    pinocchio_token::instructions::initialize_account2::InitializeAccount2<'account, Program2022>;
+    pinocchio_token::instructions::initialize_account2::InitializeAccount2<
+        'account,
+        Token2022Program,
+    >;
 
 /// Like [`InitializeAccount2`], but does not require the
 /// Rent sysvar to be provided
@@ -262,7 +275,7 @@ pub type InitializeAccount3<'account, 'address> =
     pinocchio_token::instructions::initialize_account3::InitializeAccount3<
         'account,
         'address,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Initialize the Immutable Owner extension for the given token account
@@ -276,7 +289,7 @@ pub type InitializeAccount3<'account, 'address> =
 pub type InitializeImmutableOwner<'account> =
     pinocchio_token::instructions::initialize_immutable_owner::InitializeImmutableOwner<
         'account,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Initializes a new mint and optionally deposits all the newly minted
@@ -293,7 +306,11 @@ pub type InitializeImmutableOwner<'account> =
 ///   0. `[writable]` The mint to initialize.
 ///   1. `[]` Rent sysvar.
 pub type InitializeMint<'account, 'address> =
-    pinocchio_token::instructions::initialize_mint::InitializeMint<'account, 'address, Program2022>;
+    pinocchio_token::instructions::initialize_mint::InitializeMint<
+        'account,
+        'address,
+        Token2022Program,
+    >;
 
 /// Like [`InitializeMint`], but does not require the Rent
 /// sysvar to be provided
@@ -305,7 +322,7 @@ pub type InitializeMint2<'account, 'address> =
     pinocchio_token::instructions::initialize_mint2::InitializeMint2<
         'account,
         'address,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Initializes a multisignature account with N provided signers.
@@ -332,7 +349,7 @@ pub type InitializeMultisig<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Like [`InitializeMultisig`], but does not require the
@@ -348,7 +365,7 @@ pub type InitializeMultisig2<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Mints new tokens to an account. The native mint does not support
@@ -371,7 +388,7 @@ pub type MintTo<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Mints new tokens to an account. The native mint does not support
@@ -398,7 +415,7 @@ pub type MintToChecked<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Revokes the delegate's authority.
@@ -414,7 +431,12 @@ pub type MintToChecked<'account, 'multisig, MultisigSigner> =
 ///   1. `[]` The source account's multisignature owner/delegate.
 ///   2. `..+M` `[signer]` M signer accounts.
 pub type Revoke<'account, 'multisig, MultisigSigner> =
-    pinocchio_token::instructions::revoke::Revoke<'account, 'multisig, MultisigSigner, Program2022>;
+    pinocchio_token::instructions::revoke::Revoke<
+        'account,
+        'multisig,
+        MultisigSigner,
+        Token2022Program,
+    >;
 
 /// Sets a new authority of a mint or account.
 ///
@@ -434,7 +456,7 @@ pub type SetAuthority<'account, 'address, 'multisig, MultisigSigner> =
         'address,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Given a wrapped / native token account (a token account containing SOL)
@@ -454,7 +476,7 @@ pub type SetAuthority<'account, 'address, 'multisig, MultisigSigner> =
 ///      lamports.
 ///   1. `[]` Rent sysvar.
 pub type SyncNative<'account> =
-    pinocchio_token::instructions::sync_native::SyncNative<'account, Program2022>;
+    pinocchio_token::instructions::sync_native::SyncNative<'account, Token2022Program>;
 
 /// Thaw a Frozen account using the Mint's `freeze_authority` (if set).
 ///
@@ -475,7 +497,7 @@ pub type ThawAccount<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Transfers tokens from one account to another either directly or via a
@@ -500,7 +522,7 @@ pub type Transfer<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Transfers tokens from one account to another either directly or via a
@@ -531,7 +553,7 @@ pub type TransferChecked<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Convert a `UiAmount` of tokens to a little-endian `u64` raw Amount,
@@ -555,7 +577,7 @@ pub type UiAmountToAmount<'account, 'amount> =
     pinocchio_token::instructions::ui_amount_to_amount::UiAmountToAmount<
         'account,
         'amount,
-        Program2022,
+        Token2022Program,
     >;
 
 /// Transfer lamports from a native SOL account to a destination account.
@@ -579,7 +601,7 @@ pub type UnwrapLamports<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 /// This instruction is to be used to rescue SOL sent to any `TokenProgram`
@@ -603,7 +625,7 @@ pub type WithdrawExcessLamports<'account, 'multisig, MultisigSigner> =
         'account,
         'multisig,
         MultisigSigner,
-        Program2022,
+        Token2022Program,
     >;
 
 #[cold]

--- a/programs/token-2022/src/lib.rs
+++ b/programs/token-2022/src/lib.rs
@@ -5,7 +5,7 @@ pub mod state;
 
 use {
     core::mem::MaybeUninit,
-    pinocchio_token::TokenProgram,
+    pinocchio_token::TokenInterface,
     solana_address::Address,
     solana_program_error::{ProgramError, ProgramResult},
 };
@@ -18,9 +18,9 @@ const UNINIT_BYTE: MaybeUninit<u8> = MaybeUninit::<u8>::uninit();
 ///
 /// This struct implements the `TokenProgram` trait, which statically provides
 /// the SPL Token-2022 address for instruction building.
-pub struct Program2022;
+pub struct Token2022Program;
 
-impl TokenProgram for Program2022 {
+impl TokenInterface for Token2022Program {
     const ID: Address = crate::ID;
 
     #[inline(always)]

--- a/programs/token/src/instructions/amount_to_ui_amount.rs
+++ b/programs/token/src/instructions/amount_to_ui_amount.rs
@@ -4,7 +4,7 @@ use {
             invalid_argument_error, write_bytes, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -38,7 +38,7 @@ const DATA_LEN: usize = 9;
 /// Accounts expected by this instruction:
 ///
 ///   0. `[]` The mint to calculate for.
-pub struct AmountToUiAmount<'account, Program: TokenProgram> {
+pub struct AmountToUiAmount<'account, Program: TokenInterface> {
     /// The mint to calculate for.
     pub mint: &'account AccountView,
 
@@ -49,7 +49,7 @@ pub struct AmountToUiAmount<'account, Program: TokenProgram> {
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> AmountToUiAmount<'account, Program> {
+impl<'account, Program: TokenInterface> AmountToUiAmount<'account, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -124,7 +124,7 @@ impl<'account, Program: TokenProgram> AmountToUiAmount<'account, Program> {
     }
 }
 
-impl<Program: TokenProgram> CpiWriter for AmountToUiAmount<'_, Program> {
+impl<Program: TokenInterface> CpiWriter for AmountToUiAmount<'_, Program> {
     #[inline(always)]
     fn write_accounts<'cpi>(
         &self,
@@ -153,7 +153,7 @@ impl<Program: TokenProgram> CpiWriter for AmountToUiAmount<'_, Program> {
     }
 }
 
-impl<Program: TokenProgram> super::batch::IntoBatch<Program> for AmountToUiAmount<'_, Program> {
+impl<Program: TokenInterface> super::batch::IntoBatch<Program> for AmountToUiAmount<'_, Program> {
     #[inline(always)]
     fn into_batch<'account, 'state>(
         self,

--- a/programs/token/src/instructions/amount_to_ui_amount.rs
+++ b/programs/token/src/instructions/amount_to_ui_amount.rs
@@ -91,7 +91,7 @@ impl<'account, Program: TokenInterface> AmountToUiAmount<'account, Program> {
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/approve.rs
+++ b/programs/token/src/instructions/approve.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, write_bytes, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -47,7 +47,8 @@ const DATA_LEN: usize = 9;
 ///   1. `[]` The delegate.
 ///   2. `[]` The source account's multisignature owner.
 ///   3. `..+M` `[signer]` M signer accounts.
-pub struct Approve<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram> {
+pub struct Approve<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
+{
     /// The source account.
     pub source: &'account AccountView,
 
@@ -67,7 +68,7 @@ pub struct Approve<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Prog
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> Approve<'account, '_, &'account AccountView, Program> {
+impl<'account, Program: TokenInterface> Approve<'account, '_, &'account AccountView, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -89,7 +90,7 @@ impl<'account, Program: TokenProgram> Approve<'account, '_, &'account AccountVie
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     Approve<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `Approve` instruction with a
@@ -209,7 +210,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for Approve<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -252,7 +253,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for Approve<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/approve.rs
+++ b/programs/token/src/instructions/approve.rs
@@ -151,7 +151,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -168,7 +168,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/approve_checked.rs
+++ b/programs/token/src/instructions/approve_checked.rs
@@ -177,7 +177,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -194,7 +194,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/approve_checked.rs
+++ b/programs/token/src/instructions/approve_checked.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, write_bytes, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -58,7 +58,7 @@ pub struct ApproveChecked<
     'account,
     'multisig,
     MultisigSigner: AsRef<AccountView>,
-    Program: TokenProgram,
+    Program: TokenInterface,
 > {
     /// The source account.
     pub source: &'account AccountView,
@@ -85,7 +85,9 @@ pub struct ApproveChecked<
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> ApproveChecked<'account, '_, &'account AccountView, Program> {
+impl<'account, Program: TokenInterface>
+    ApproveChecked<'account, '_, &'account AccountView, Program>
+{
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -110,7 +112,7 @@ impl<'account, Program: TokenProgram> ApproveChecked<'account, '_, &'account Acc
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     ApproveChecked<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `ApproveChecked` instruction with a
@@ -234,7 +236,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for ApproveChecked<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -279,7 +281,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for ApproveChecked<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/batch.rs
+++ b/programs/token/src/instructions/batch.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 use {
-    crate::{instructions::invalid_argument_error, TokenProgram},
+    crate::{instructions::invalid_argument_error, TokenInterface},
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_address::Address,
     solana_instruction_view::{
@@ -29,7 +29,7 @@ const IX_HEADER_SIZE: usize = 2;
 
 /// A collection of instructions that can be serialized into a token `Batch`
 /// instruction.
-pub struct Batch<'account, 'state, Program: TokenProgram> {
+pub struct Batch<'account, 'state, Program: TokenInterface> {
     /// The instruction data for the batch instruction.
     ///
     /// The first byte is reserved for the batch instruction discriminator,
@@ -57,7 +57,7 @@ pub struct Batch<'account, 'state, Program: TokenProgram> {
     _program: PhantomData<Program>,
 }
 
-impl<'account, 'state, Program: TokenProgram> Batch<'account, 'state, Program>
+impl<'account, 'state, Program: TokenInterface> Batch<'account, 'state, Program>
 where
     'account: 'state,
 {
@@ -228,7 +228,7 @@ where
 
 #[cfg(feature = "alloc")]
 /// A state object that contains the buffers for a `Batch` instruction.
-pub struct BatchState<'account, Program: TokenProgram> {
+pub struct BatchState<'account, Program: TokenInterface> {
     /// Container for the instruction data of the batch instruction.
     data: Box<[MaybeUninit<u8>]>,
 
@@ -243,7 +243,7 @@ pub struct BatchState<'account, Program: TokenProgram> {
 }
 
 #[cfg(feature = "alloc")]
-impl<'account, Program: TokenProgram> BatchState<'account, Program> {
+impl<'account, Program: TokenInterface> BatchState<'account, Program> {
     #[inline(always)]
     pub fn new(accounts_len: usize, data_len: usize) -> Self {
         Self {
@@ -270,7 +270,7 @@ impl<'account, Program: TokenProgram> BatchState<'account, Program> {
 }
 
 /// A trait for instructions that can be consumed directly into a `Batch`.
-pub trait IntoBatch<Program: TokenProgram> {
+pub trait IntoBatch<Program: TokenInterface> {
     /// Serializes `self` into the provided batch.
     fn into_batch<'account, 'state>(
         self,

--- a/programs/token/src/instructions/batch.rs
+++ b/programs/token/src/instructions/batch.rs
@@ -137,7 +137,7 @@ where
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -154,7 +154,7 @@ where
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/burn.rs
+++ b/programs/token/src/instructions/burn.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, write_bytes, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -47,7 +47,7 @@ const DATA_LEN: usize = 9;
 ///   1. `[writable]` The token mint.
 ///   2. `[]` The account's multisignature owner/delegate.
 ///   3. `..+M` `[signer]` M signer accounts.
-pub struct Burn<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram> {
+pub struct Burn<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface> {
     /// The account to burn from.
     pub account: &'account AccountView,
 
@@ -67,7 +67,7 @@ pub struct Burn<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> Burn<'account, '_, &'account AccountView, Program> {
+impl<'account, Program: TokenInterface> Burn<'account, '_, &'account AccountView, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -90,7 +90,7 @@ impl<'account, Program: TokenProgram> Burn<'account, '_, &'account AccountView, 
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     Burn<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `Burn` instruction with a
@@ -210,7 +210,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for Burn<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -253,7 +253,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for Burn<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/burn.rs
+++ b/programs/token/src/instructions/burn.rs
@@ -151,7 +151,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -168,7 +168,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/burn_checked.rs
+++ b/programs/token/src/instructions/burn_checked.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, write_bytes, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -57,7 +57,7 @@ pub struct BurnChecked<
     'account,
     'multisig,
     MultisigSigner: AsRef<AccountView>,
-    Program: TokenProgram,
+    Program: TokenInterface,
 > {
     /// The account to burn from.
     pub account: &'account AccountView,
@@ -81,7 +81,7 @@ pub struct BurnChecked<
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> BurnChecked<'account, '_, &'account AccountView, Program> {
+impl<'account, Program: TokenInterface> BurnChecked<'account, '_, &'account AccountView, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -105,7 +105,7 @@ impl<'account, Program: TokenProgram> BurnChecked<'account, '_, &'account Accoun
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     BurnChecked<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `BurnChecked` instruction with a
@@ -227,7 +227,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for BurnChecked<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -270,7 +270,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for BurnChecked<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/burn_checked.rs
+++ b/programs/token/src/instructions/burn_checked.rs
@@ -168,7 +168,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -185,7 +185,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/close_account.rs
+++ b/programs/token/src/instructions/close_account.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -50,7 +50,7 @@ pub struct CloseAccount<
     'account,
     'multisig,
     MultisigSigner: AsRef<AccountView>,
-    Program: TokenProgram,
+    Program: TokenInterface,
 > {
     /// The account to close.
     pub account: &'account AccountView,
@@ -68,7 +68,7 @@ pub struct CloseAccount<
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> CloseAccount<'account, '_, &'account AccountView, Program> {
+impl<'account, Program: TokenInterface> CloseAccount<'account, '_, &'account AccountView, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -89,7 +89,7 @@ impl<'account, Program: TokenProgram> CloseAccount<'account, '_, &'account Accou
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     CloseAccount<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `CloseAccount` instruction with a
@@ -207,7 +207,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for CloseAccount<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -250,7 +250,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for CloseAccount<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/close_account.rs
+++ b/programs/token/src/instructions/close_account.rs
@@ -148,7 +148,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -165,7 +165,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/freeze_account.rs
+++ b/programs/token/src/instructions/freeze_account.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -50,7 +50,7 @@ pub struct FreezeAccount<
     'account,
     'multisig,
     MultisigSigner: AsRef<AccountView>,
-    Program: TokenProgram,
+    Program: TokenInterface,
 > {
     /// The account to freeze.
     pub account: &'account AccountView,
@@ -68,7 +68,9 @@ pub struct FreezeAccount<
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> FreezeAccount<'account, '_, &'account AccountView, Program> {
+impl<'account, Program: TokenInterface>
+    FreezeAccount<'account, '_, &'account AccountView, Program>
+{
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -90,7 +92,7 @@ impl<'account, Program: TokenProgram> FreezeAccount<'account, '_, &'account Acco
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     FreezeAccount<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `FreezeAccount` instruction with a
@@ -208,7 +210,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for FreezeAccount<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -251,7 +253,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for FreezeAccount<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/freeze_account.rs
+++ b/programs/token/src/instructions/freeze_account.rs
@@ -151,7 +151,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -168,7 +168,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/get_account_data_size.rs
+++ b/programs/token/src/instructions/get_account_data_size.rs
@@ -82,7 +82,7 @@ impl<'account, Program: TokenInterface> GetAccountDataSize<'account, Program> {
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/get_account_data_size.rs
+++ b/programs/token/src/instructions/get_account_data_size.rs
@@ -4,7 +4,7 @@ use {
             invalid_argument_error, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -35,7 +35,7 @@ const DATA_LEN: usize = 1;
 /// Accounts expected by this instruction:
 ///
 ///   0. `[]` The mint to calculate for.
-pub struct GetAccountDataSize<'account, Program: TokenProgram> {
+pub struct GetAccountDataSize<'account, Program: TokenInterface> {
     /// The mint to calculate for.
     pub mint: &'account AccountView,
 
@@ -43,7 +43,7 @@ pub struct GetAccountDataSize<'account, Program: TokenProgram> {
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> GetAccountDataSize<'account, Program> {
+impl<'account, Program: TokenInterface> GetAccountDataSize<'account, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -115,7 +115,7 @@ impl<'account, Program: TokenProgram> GetAccountDataSize<'account, Program> {
     }
 }
 
-impl<Program: TokenProgram> CpiWriter for GetAccountDataSize<'_, Program> {
+impl<Program: TokenInterface> CpiWriter for GetAccountDataSize<'_, Program> {
     #[inline(always)]
     fn write_accounts<'cpi>(
         &self,
@@ -144,7 +144,7 @@ impl<Program: TokenProgram> CpiWriter for GetAccountDataSize<'_, Program> {
     }
 }
 
-impl<Program: TokenProgram> super::batch::IntoBatch<Program> for GetAccountDataSize<'_, Program> {
+impl<Program: TokenInterface> super::batch::IntoBatch<Program> for GetAccountDataSize<'_, Program> {
     #[inline(always)]
     fn into_batch<'account, 'state>(
         self,

--- a/programs/token/src/instructions/initialize_account.rs
+++ b/programs/token/src/instructions/initialize_account.rs
@@ -4,7 +4,7 @@ use {
             account_borrow_failed_error, invalid_argument_error, CpiWriter, UNINIT_BYTE,
             UNINIT_CPI_ACCOUNT, UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -44,7 +44,7 @@ const DATA_LEN: usize = 1;
 ///   1. `[]` The mint this account will be associated with.
 ///   2. `[]` The new account's owner/multisignature.
 ///   3. `[]` Rent sysvar.
-pub struct InitializeAccount<'account, Program: TokenProgram> {
+pub struct InitializeAccount<'account, Program: TokenInterface> {
     /// The account to initialize.
     pub account: &'account AccountView,
 
@@ -61,7 +61,7 @@ pub struct InitializeAccount<'account, Program: TokenProgram> {
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> InitializeAccount<'account, Program> {
+impl<'account, Program: TokenInterface> InitializeAccount<'account, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -141,7 +141,7 @@ impl<'account, Program: TokenProgram> InitializeAccount<'account, Program> {
     }
 }
 
-impl<Program: TokenProgram> CpiWriter for InitializeAccount<'_, Program> {
+impl<Program: TokenInterface> CpiWriter for InitializeAccount<'_, Program> {
     #[inline(always)]
     fn write_accounts<'cpi>(
         &self,
@@ -182,7 +182,7 @@ impl<Program: TokenProgram> CpiWriter for InitializeAccount<'_, Program> {
     }
 }
 
-impl<Program: TokenProgram> super::batch::IntoBatch<Program> for InitializeAccount<'_, Program> {
+impl<Program: TokenInterface> super::batch::IntoBatch<Program> for InitializeAccount<'_, Program> {
     #[inline(always)]
     fn into_batch<'account, 'state>(
         self,

--- a/programs/token/src/instructions/initialize_account.rs
+++ b/programs/token/src/instructions/initialize_account.rs
@@ -108,7 +108,7 @@ impl<'account, Program: TokenInterface> InitializeAccount<'account, Program> {
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/initialize_account2.rs
+++ b/programs/token/src/instructions/initialize_account2.rs
@@ -4,7 +4,7 @@ use {
             account_borrow_failed_error, invalid_argument_error, write_bytes, CpiWriter,
             UNINIT_BYTE, UNINIT_CPI_ACCOUNT, UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -38,7 +38,7 @@ const DATA_LEN: usize = 33;
 ///   0. `[writable]` The account to initialize.
 ///   1. `[]` The mint this account will be associated with.
 ///   2. `[]` Rent sysvar.
-pub struct InitializeAccount2<'account, Program: TokenProgram> {
+pub struct InitializeAccount2<'account, Program: TokenInterface> {
     /// The account to initialize.
     pub account: &'account AccountView,
 
@@ -55,7 +55,7 @@ pub struct InitializeAccount2<'account, Program: TokenProgram> {
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> InitializeAccount2<'account, Program> {
+impl<'account, Program: TokenInterface> InitializeAccount2<'account, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -135,7 +135,7 @@ impl<'account, Program: TokenProgram> InitializeAccount2<'account, Program> {
     }
 }
 
-impl<Program: TokenProgram> CpiWriter for InitializeAccount2<'_, Program> {
+impl<Program: TokenInterface> CpiWriter for InitializeAccount2<'_, Program> {
     #[inline(always)]
     fn write_accounts<'cpi>(
         &self,
@@ -164,7 +164,7 @@ impl<Program: TokenProgram> CpiWriter for InitializeAccount2<'_, Program> {
     }
 }
 
-impl<Program: TokenProgram> super::batch::IntoBatch<Program> for InitializeAccount2<'_, Program> {
+impl<Program: TokenInterface> super::batch::IntoBatch<Program> for InitializeAccount2<'_, Program> {
     #[inline(always)]
     fn into_batch<'account, 'state>(
         self,

--- a/programs/token/src/instructions/initialize_account2.rs
+++ b/programs/token/src/instructions/initialize_account2.rs
@@ -102,7 +102,7 @@ impl<'account, Program: TokenInterface> InitializeAccount2<'account, Program> {
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/initialize_account3.rs
+++ b/programs/token/src/instructions/initialize_account3.rs
@@ -93,7 +93,7 @@ impl<'account, 'address, Program: TokenInterface> InitializeAccount3<'account, '
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/initialize_account3.rs
+++ b/programs/token/src/instructions/initialize_account3.rs
@@ -4,7 +4,7 @@ use {
             account_borrow_failed_error, invalid_argument_error, write_bytes, CpiWriter,
             UNINIT_BYTE, UNINIT_CPI_ACCOUNT, UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -34,7 +34,7 @@ const DATA_LEN: usize = 33;
 ///
 ///   0. `[writable]` The account to initialize.
 ///   1. `[]` The mint this account will be associated with.
-pub struct InitializeAccount3<'account, 'address, Program: TokenProgram> {
+pub struct InitializeAccount3<'account, 'address, Program: TokenInterface> {
     /// The account to initialize.
     pub account: &'account AccountView,
 
@@ -48,7 +48,7 @@ pub struct InitializeAccount3<'account, 'address, Program: TokenProgram> {
     _program: PhantomData<Program>,
 }
 
-impl<'account, 'address, Program: TokenProgram> InitializeAccount3<'account, 'address, Program> {
+impl<'account, 'address, Program: TokenInterface> InitializeAccount3<'account, 'address, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -126,7 +126,7 @@ impl<'account, 'address, Program: TokenProgram> InitializeAccount3<'account, 'ad
     }
 }
 
-impl<Program: TokenProgram> CpiWriter for InitializeAccount3<'_, '_, Program> {
+impl<Program: TokenInterface> CpiWriter for InitializeAccount3<'_, '_, Program> {
     #[inline(always)]
     fn write_accounts<'cpi>(
         &self,
@@ -155,7 +155,7 @@ impl<Program: TokenProgram> CpiWriter for InitializeAccount3<'_, '_, Program> {
     }
 }
 
-impl<Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<Program: TokenInterface> super::batch::IntoBatch<Program>
     for InitializeAccount3<'_, '_, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/initialize_immutable_owner.rs
+++ b/programs/token/src/instructions/initialize_immutable_owner.rs
@@ -4,7 +4,7 @@ use {
             account_borrow_failed_error, invalid_argument_error, CpiWriter, UNINIT_BYTE,
             UNINIT_CPI_ACCOUNT, UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -34,7 +34,7 @@ const DATA_LEN: usize = 1;
 /// Accounts expected by this instruction:
 ///
 ///   0. `[writable]` The account to initialize.
-pub struct InitializeImmutableOwner<'account, Program: TokenProgram> {
+pub struct InitializeImmutableOwner<'account, Program: TokenInterface> {
     /// The account to initialize.
     pub account: &'account AccountView,
 
@@ -42,7 +42,7 @@ pub struct InitializeImmutableOwner<'account, Program: TokenProgram> {
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> InitializeImmutableOwner<'account, Program> {
+impl<'account, Program: TokenInterface> InitializeImmutableOwner<'account, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -114,7 +114,7 @@ impl<'account, Program: TokenProgram> InitializeImmutableOwner<'account, Program
     }
 }
 
-impl<Program: TokenProgram> CpiWriter for InitializeImmutableOwner<'_, Program> {
+impl<Program: TokenInterface> CpiWriter for InitializeImmutableOwner<'_, Program> {
     #[inline(always)]
     fn write_accounts<'cpi>(
         &self,
@@ -143,7 +143,7 @@ impl<Program: TokenProgram> CpiWriter for InitializeImmutableOwner<'_, Program> 
     }
 }
 
-impl<Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<Program: TokenInterface> super::batch::IntoBatch<Program>
     for InitializeImmutableOwner<'_, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/initialize_immutable_owner.rs
+++ b/programs/token/src/instructions/initialize_immutable_owner.rs
@@ -81,7 +81,7 @@ impl<'account, Program: TokenInterface> InitializeImmutableOwner<'account, Progr
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/initialize_mint.rs
+++ b/programs/token/src/instructions/initialize_mint.rs
@@ -4,7 +4,7 @@ use {
             account_borrow_failed_error, invalid_argument_error, write_bytes, CpiWriter,
             UNINIT_BYTE, UNINIT_CPI_ACCOUNT, UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -42,7 +42,7 @@ const MAX_DATA_LEN: usize = 67;
 ///
 ///   0. `[writable]` The mint to initialize.
 ///   1. `[]` Rent sysvar.
-pub struct InitializeMint<'account, 'address, Program: TokenProgram> {
+pub struct InitializeMint<'account, 'address, Program: TokenInterface> {
     /// The mint to initialize.
     pub mint: &'account AccountView,
 
@@ -62,7 +62,7 @@ pub struct InitializeMint<'account, 'address, Program: TokenProgram> {
     _program: PhantomData<Program>,
 }
 
-impl<'account, 'address, Program: TokenProgram> InitializeMint<'account, 'address, Program> {
+impl<'account, 'address, Program: TokenInterface> InitializeMint<'account, 'address, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -144,7 +144,7 @@ impl<'account, 'address, Program: TokenProgram> InitializeMint<'account, 'addres
     }
 }
 
-impl<Program: TokenProgram> CpiWriter for InitializeMint<'_, '_, Program> {
+impl<Program: TokenInterface> CpiWriter for InitializeMint<'_, '_, Program> {
     #[inline(always)]
     fn write_accounts<'cpi>(
         &self,
@@ -178,7 +178,7 @@ impl<Program: TokenProgram> CpiWriter for InitializeMint<'_, '_, Program> {
     }
 }
 
-impl<Program: TokenProgram> super::batch::IntoBatch<Program> for InitializeMint<'_, '_, Program> {
+impl<Program: TokenInterface> super::batch::IntoBatch<Program> for InitializeMint<'_, '_, Program> {
     #[inline(always)]
     fn into_batch<'account, 'state>(
         self,

--- a/programs/token/src/instructions/initialize_mint.rs
+++ b/programs/token/src/instructions/initialize_mint.rs
@@ -111,7 +111,7 @@ impl<'account, 'address, Program: TokenInterface> InitializeMint<'account, 'addr
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/initialize_mint2.rs
+++ b/programs/token/src/instructions/initialize_mint2.rs
@@ -4,7 +4,7 @@ use {
             account_borrow_failed_error, invalid_argument_error, write_bytes, CpiWriter,
             UNINIT_BYTE, UNINIT_CPI_ACCOUNT, UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -35,7 +35,7 @@ const MAX_DATA_LEN: usize = 67;
 /// Accounts expected by this instruction:
 ///
 ///   0. `[writable]` The mint to initialize.
-pub struct InitializeMint2<'account, 'address, Program: TokenProgram> {
+pub struct InitializeMint2<'account, 'address, Program: TokenInterface> {
     /// The mint to initialize.
     pub mint: &'account AccountView,
 
@@ -52,7 +52,7 @@ pub struct InitializeMint2<'account, 'address, Program: TokenProgram> {
     _program: PhantomData<Program>,
 }
 
-impl<'account, 'address, Program: TokenProgram> InitializeMint2<'account, 'address, Program> {
+impl<'account, 'address, Program: TokenInterface> InitializeMint2<'account, 'address, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -132,7 +132,7 @@ impl<'account, 'address, Program: TokenProgram> InitializeMint2<'account, 'addre
     }
 }
 
-impl<Program: TokenProgram> CpiWriter for InitializeMint2<'_, '_, Program> {
+impl<Program: TokenInterface> CpiWriter for InitializeMint2<'_, '_, Program> {
     #[inline(always)]
     fn write_accounts<'cpi>(
         &self,
@@ -166,7 +166,9 @@ impl<Program: TokenProgram> CpiWriter for InitializeMint2<'_, '_, Program> {
     }
 }
 
-impl<Program: TokenProgram> super::batch::IntoBatch<Program> for InitializeMint2<'_, '_, Program> {
+impl<Program: TokenInterface> super::batch::IntoBatch<Program>
+    for InitializeMint2<'_, '_, Program>
+{
     #[inline(always)]
     fn into_batch<'account, 'state>(
         self,

--- a/programs/token/src/instructions/initialize_mint2.rs
+++ b/programs/token/src/instructions/initialize_mint2.rs
@@ -99,7 +99,7 @@ impl<'account, 'address, Program: TokenInterface> InitializeMint2<'account, 'add
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/initialize_multisig.rs
+++ b/programs/token/src/instructions/initialize_multisig.rs
@@ -4,7 +4,7 @@ use {
             account_borrow_failed_error, invalid_argument_error, CpiWriter, UNINIT_BYTE,
             UNINIT_CPI_ACCOUNT, UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -56,7 +56,7 @@ pub struct InitializeMultisig<
     'account,
     'multisig,
     MultisigSigner: AsRef<AccountView>,
-    Program: TokenProgram,
+    Program: TokenInterface,
 > where
     'account: 'multisig,
 {
@@ -77,7 +77,7 @@ pub struct InitializeMultisig<
     _program: PhantomData<Program>,
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     InitializeMultisig<'account, 'multisig, MultisigSigner, Program>
 where
     'account: 'multisig,
@@ -168,7 +168,7 @@ where
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for InitializeMultisig<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -209,7 +209,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for InitializeMultisig<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/initialize_multisig.rs
+++ b/programs/token/src/instructions/initialize_multisig.rs
@@ -131,7 +131,7 @@ where
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/initialize_multisig2.rs
+++ b/programs/token/src/instructions/initialize_multisig2.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -43,7 +43,7 @@ pub struct InitializeMultisig2<
     'account,
     'multisig,
     MultisigSigner: AsRef<AccountView>,
-    Program: TokenProgram,
+    Program: TokenInterface,
 > where
     'account: 'multisig,
 {
@@ -61,7 +61,7 @@ pub struct InitializeMultisig2<
     _program: PhantomData<Program>,
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     InitializeMultisig2<'account, 'multisig, MultisigSigner, Program>
 where
     'account: 'multisig,
@@ -147,7 +147,7 @@ where
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for InitializeMultisig2<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -178,7 +178,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for InitializeMultisig2<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/initialize_multisig2.rs
+++ b/programs/token/src/instructions/initialize_multisig2.rs
@@ -110,7 +110,7 @@ where
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/mint_to.rs
+++ b/programs/token/src/instructions/mint_to.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, write_bytes, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -47,7 +47,8 @@ const DATA_LEN: usize = 9;
 ///   1. `[writable]` The account to mint tokens to.
 ///   2. `[]` The mint's multisignature mint-tokens authority.
 ///   3. `..+M` `[signer]` M signer accounts.
-pub struct MintTo<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram> {
+pub struct MintTo<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
+{
     /// The mint.
     pub mint: &'account AccountView,
 
@@ -67,7 +68,7 @@ pub struct MintTo<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Progr
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> MintTo<'account, '_, &'account AccountView, Program> {
+impl<'account, Program: TokenInterface> MintTo<'account, '_, &'account AccountView, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -89,7 +90,7 @@ impl<'account, Program: TokenProgram> MintTo<'account, '_, &'account AccountView
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     MintTo<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `MintTo` instruction with a
@@ -209,7 +210,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for MintTo<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -252,7 +253,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for MintTo<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/mint_to.rs
+++ b/programs/token/src/instructions/mint_to.rs
@@ -151,7 +151,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -168,7 +168,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/mint_to_checked.rs
+++ b/programs/token/src/instructions/mint_to_checked.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, write_bytes, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -56,7 +56,7 @@ pub struct MintToChecked<
     'account,
     'multisig,
     MultisigSigner: AsRef<AccountView>,
-    Program: TokenProgram,
+    Program: TokenInterface,
 > {
     /// The mint.
     pub mint: &'account AccountView,
@@ -81,7 +81,9 @@ pub struct MintToChecked<
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> MintToChecked<'account, '_, &'account AccountView, Program> {
+impl<'account, Program: TokenInterface>
+    MintToChecked<'account, '_, &'account AccountView, Program>
+{
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -104,7 +106,7 @@ impl<'account, Program: TokenProgram> MintToChecked<'account, '_, &'account Acco
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     MintToChecked<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `MintToChecked` instruction with a
@@ -226,7 +228,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for MintToChecked<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -269,7 +271,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for MintToChecked<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/mint_to_checked.rs
+++ b/programs/token/src/instructions/mint_to_checked.rs
@@ -169,7 +169,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -186,7 +186,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/mod.rs
+++ b/programs/token/src/instructions/mod.rs
@@ -3,7 +3,7 @@ pub use crate::instructions::{
     unwrap_lamports::Amount,
 };
 use {
-    crate::Program,
+    crate::TokenProgram,
     core::mem::MaybeUninit,
     solana_instruction_view::{cpi::CpiAccount, InstructionAccount},
     solana_program_error::ProgramError,
@@ -59,7 +59,7 @@ const UNINIT_INSTRUCTION_ACCOUNT: MaybeUninit<InstructionAccount> =
 /// Accounts expected by this instruction:
 ///
 ///   0. `[]` The mint to calculate for.
-pub type AmountToUiAmount<'account> = amount_to_ui_amount::AmountToUiAmount<'account, Program>;
+pub type AmountToUiAmount<'account> = amount_to_ui_amount::AmountToUiAmount<'account, TokenProgram>;
 
 /// Approves a delegate. A delegate is given the authority over tokens on
 /// behalf of the source account's owner.
@@ -77,7 +77,7 @@ pub type AmountToUiAmount<'account> = amount_to_ui_amount::AmountToUiAmount<'acc
 ///   2. `[]` The source account's multisignature owner.
 ///   3. `..+M` `[signer]` M signer accounts.
 pub type Approve<'account, 'multisig, MultisigSigner> =
-    approve::Approve<'account, 'multisig, MultisigSigner, Program>;
+    approve::Approve<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Approves a delegate. A delegate is given the authority over tokens on
 /// behalf of the source account's owner.
@@ -101,15 +101,15 @@ pub type Approve<'account, 'multisig, MultisigSigner> =
 ///   3. `[]` The source account's multisignature owner.
 ///   4. `..+M` `[signer]` M signer accounts.
 pub type ApproveChecked<'account, 'multisig, MultisigSigner> =
-    approve_checked::ApproveChecked<'account, 'multisig, MultisigSigner, Program>;
+    approve_checked::ApproveChecked<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// A collection of instructions that can be serialized into a token `Batch`
 /// instruction.
-pub type Batch<'account, 'state> = batch::Batch<'account, 'state, Program>;
+pub type Batch<'account, 'state> = batch::Batch<'account, 'state, TokenProgram>;
 
 #[cfg(feature = "alloc")]
 /// A state object that contains the buffers for a `Batch` instruction.
-pub type BatchState<'account> = batch::BatchState<'account, Program>;
+pub type BatchState<'account> = batch::BatchState<'account, TokenProgram>;
 
 /// Burns tokens by removing them from an account. `Burn` does not support
 /// accounts associated with the native mint, use `CloseAccount` instead.
@@ -127,7 +127,7 @@ pub type BatchState<'account> = batch::BatchState<'account, Program>;
 ///   2. `[]` The account's multisignature owner/delegate.
 ///   3. `..+M` `[signer]` M signer accounts.
 pub type Burn<'account, 'multisig, MultisigSigner> =
-    burn::Burn<'account, 'multisig, MultisigSigner, Program>;
+    burn::Burn<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Burns tokens by removing them from an account.
 /// [`BurnChecked`] does not support accounts
@@ -150,7 +150,7 @@ pub type Burn<'account, 'multisig, MultisigSigner> =
 ///   2. `[]` The account's multisignature owner/delegate.
 ///   3. `..+M` `[signer]` M signer accounts.
 pub type BurnChecked<'account, 'multisig, MultisigSigner> =
-    burn_checked::BurnChecked<'account, 'multisig, MultisigSigner, Program>;
+    burn_checked::BurnChecked<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Close an account by transferring all its SOL to the destination account.
 /// Non-native accounts may only be closed if its token amount is zero.
@@ -168,7 +168,7 @@ pub type BurnChecked<'account, 'multisig, MultisigSigner> =
 ///   2. `[]` The account's multisignature owner.
 ///   3. `..+M` `[signer]` M signer accounts.
 pub type CloseAccount<'account, 'multisig, MultisigSigner> =
-    close_account::CloseAccount<'account, 'multisig, MultisigSigner, Program>;
+    close_account::CloseAccount<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Freeze an Initialized account using the Mint's `freeze_authority` (if
 /// set).
@@ -186,7 +186,7 @@ pub type CloseAccount<'account, 'multisig, MultisigSigner> =
 ///   2. `[]` The mint's multisignature freeze authority.
 ///   3. `..+M` `[signer]` M signer accounts.
 pub type FreezeAccount<'account, 'multisig, MultisigSigner> =
-    freeze_account::FreezeAccount<'account, 'multisig, MultisigSigner, Program>;
+    freeze_account::FreezeAccount<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Gets the required size of an account for the given mint as a
 /// little-endian `u64`.
@@ -198,7 +198,7 @@ pub type FreezeAccount<'account, 'multisig, MultisigSigner> =
 ///
 ///   0. `[]` The mint to calculate for.
 pub type GetAccountDataSize<'account> =
-    get_account_data_size::GetAccountDataSize<'account, Program>;
+    get_account_data_size::GetAccountDataSize<'account, TokenProgram>;
 
 /// Initializes a new account to hold tokens. If this account is associated
 /// with the native mint then the token balance of the initialized account
@@ -218,7 +218,8 @@ pub type GetAccountDataSize<'account> =
 ///   1. `[]` The mint this account will be associated with.
 ///   2. `[]` The new account's owner/multisignature.
 ///   3. `[]` Rent sysvar.
-pub type InitializeAccount<'account> = initialize_account::InitializeAccount<'account, Program>;
+pub type InitializeAccount<'account> =
+    initialize_account::InitializeAccount<'account, TokenProgram>;
 
 /// Like [`InitializeAccount`], but the owner pubkey is
 /// passed via instruction data rather than the accounts list. This
@@ -231,7 +232,8 @@ pub type InitializeAccount<'account> = initialize_account::InitializeAccount<'ac
 ///   0. `[writable]` The account to initialize.
 ///   1. `[]` The mint this account will be associated with.
 ///   2. `[]` Rent sysvar.
-pub type InitializeAccount2<'account> = initialize_account2::InitializeAccount2<'account, Program>;
+pub type InitializeAccount2<'account> =
+    initialize_account2::InitializeAccount2<'account, TokenProgram>;
 
 /// Like [`InitializeAccount2`], but does not require the
 /// Rent sysvar to be provided
@@ -241,7 +243,7 @@ pub type InitializeAccount2<'account> = initialize_account2::InitializeAccount2<
 ///   0. `[writable]` The account to initialize.
 ///   1. `[]` The mint this account will be associated with.
 pub type InitializeAccount3<'account, 'address> =
-    initialize_account3::InitializeAccount3<'account, 'address, Program>;
+    initialize_account3::InitializeAccount3<'account, 'address, TokenProgram>;
 
 /// Initialize the Immutable Owner extension for the given token account
 ///
@@ -252,7 +254,7 @@ pub type InitializeAccount3<'account, 'address> =
 ///
 ///   0. `[writable]` The account to initialize.
 pub type InitializeImmutableOwner<'account> =
-    initialize_immutable_owner::InitializeImmutableOwner<'account, Program>;
+    initialize_immutable_owner::InitializeImmutableOwner<'account, TokenProgram>;
 
 /// Initializes a new mint and optionally deposits all the newly minted
 /// tokens in an account.
@@ -268,7 +270,7 @@ pub type InitializeImmutableOwner<'account> =
 ///   0. `[writable]` The mint to initialize.
 ///   1. `[]` Rent sysvar.
 pub type InitializeMint<'account, 'address> =
-    initialize_mint::InitializeMint<'account, 'address, Program>;
+    initialize_mint::InitializeMint<'account, 'address, TokenProgram>;
 
 /// Like [`InitializeMint`], but does not require the Rent
 /// sysvar to be provided
@@ -277,7 +279,7 @@ pub type InitializeMint<'account, 'address> =
 ///
 ///   0. `[writable]` The mint to initialize.
 pub type InitializeMint2<'account, 'address> =
-    initialize_mint2::InitializeMint2<'account, 'address, Program>;
+    initialize_mint2::InitializeMint2<'account, 'address, TokenProgram>;
 
 /// Initializes a multisignature account with N provided signers.
 ///
@@ -299,7 +301,7 @@ pub type InitializeMint2<'account, 'address> =
 ///   2. `..+N` `[signer]` The signer accounts, must equal to N where `1 <= N <=
 ///      11`.
 pub type InitializeMultisig<'account, 'multisig, MultisigSigner> =
-    initialize_multisig::InitializeMultisig<'account, 'multisig, MultisigSigner, Program>;
+    initialize_multisig::InitializeMultisig<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Like [`InitializeMultisig`], but does not require the
 /// Rent sysvar to be provided
@@ -310,7 +312,7 @@ pub type InitializeMultisig<'account, 'multisig, MultisigSigner> =
 ///   1. `..+N` `[signer]` The signer accounts, must equal to N where `1 <= N <=
 ///      11`.
 pub type InitializeMultisig2<'account, 'multisig, MultisigSigner> =
-    initialize_multisig2::InitializeMultisig2<'account, 'multisig, MultisigSigner, Program>;
+    initialize_multisig2::InitializeMultisig2<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Mints new tokens to an account. The native mint does not support
 /// minting.
@@ -328,7 +330,7 @@ pub type InitializeMultisig2<'account, 'multisig, MultisigSigner> =
 ///   2. `[]` The mint's multisignature mint-tokens authority.
 ///   3. `..+M` `[signer]` M signer accounts.
 pub type MintTo<'account, 'multisig, MultisigSigner> =
-    mint_to::MintTo<'account, 'multisig, MultisigSigner, Program>;
+    mint_to::MintTo<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Mints new tokens to an account. The native mint does not support
 /// minting.
@@ -350,7 +352,7 @@ pub type MintTo<'account, 'multisig, MultisigSigner> =
 ///   2. `[]` The mint's multisignature mint-tokens authority.
 ///   3. `..+M` `[signer]` M signer accounts.
 pub type MintToChecked<'account, 'multisig, MultisigSigner> =
-    mint_to_checked::MintToChecked<'account, 'multisig, MultisigSigner, Program>;
+    mint_to_checked::MintToChecked<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Revokes the delegate's authority.
 ///
@@ -365,7 +367,7 @@ pub type MintToChecked<'account, 'multisig, MultisigSigner> =
 ///   1. `[]` The source account's multisignature owner/delegate.
 ///   2. `..+M` `[signer]` M signer accounts.
 pub type Revoke<'account, 'multisig, MultisigSigner> =
-    revoke::Revoke<'account, 'multisig, MultisigSigner, Program>;
+    revoke::Revoke<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Sets a new authority of a mint or account.
 ///
@@ -380,7 +382,7 @@ pub type Revoke<'account, 'multisig, MultisigSigner> =
 ///   1. `[]` The mint's or account's current multisignature authority.
 ///   2. `..+M` `[signer]` M signer accounts.
 pub type SetAuthority<'account, 'address, 'multisig, MultisigSigner> =
-    set_authority::SetAuthority<'account, 'address, 'multisig, MultisigSigner, Program>;
+    set_authority::SetAuthority<'account, 'address, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Given a wrapped / native token account (a token account containing SOL)
 /// updates its amount field based on the account's underlying `lamports`.
@@ -398,7 +400,7 @@ pub type SetAuthority<'account, 'address, 'multisig, MultisigSigner> =
 ///   0. `[writable]` The native token account to sync with its underlying
 ///      lamports.
 ///   1. `[]` Rent sysvar.
-pub type SyncNative<'account> = sync_native::SyncNative<'account, Program>;
+pub type SyncNative<'account> = sync_native::SyncNative<'account, TokenProgram>;
 
 /// Thaw a Frozen account using the Mint's `freeze_authority` (if set).
 ///
@@ -415,7 +417,7 @@ pub type SyncNative<'account> = sync_native::SyncNative<'account, Program>;
 ///   2. `[]` The mint's multisignature freeze authority.
 ///   3. `..+M` `[signer]` M signer accounts.
 pub type ThawAccount<'account, 'multisig, MultisigSigner> =
-    thaw_account::ThawAccount<'account, 'multisig, MultisigSigner, Program>;
+    thaw_account::ThawAccount<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Transfers tokens from one account to another either directly or via a
 /// delegate. If this account is associated with the native mint then equal
@@ -435,7 +437,7 @@ pub type ThawAccount<'account, 'multisig, MultisigSigner> =
 ///   2. `[]` The source account's multisignature owner/delegate.
 ///   3. `..+M` `[signer]` M signer accounts.
 pub type Transfer<'account, 'multisig, MultisigSigner> =
-    transfer::Transfer<'account, 'multisig, MultisigSigner, Program>;
+    transfer::Transfer<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Transfers tokens from one account to another either directly or via a
 /// delegate. If this account is associated with the native mint then equal
@@ -461,7 +463,7 @@ pub type Transfer<'account, 'multisig, MultisigSigner> =
 ///   3. `[]` The source account's multisignature owner/delegate.
 ///   4. `..+M` `[signer]` M signer accounts.
 pub type TransferChecked<'account, 'multisig, MultisigSigner> =
-    transfer_checked::TransferChecked<'account, 'multisig, MultisigSigner, Program>;
+    transfer_checked::TransferChecked<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// Convert a `UiAmount` of tokens to a little-endian `u64` raw Amount,
 /// using the given mint. In this version of the program, the mint can
@@ -474,7 +476,7 @@ pub type TransferChecked<'account, 'multisig, MultisigSigner> =
 ///
 ///   0. `[]` The mint to calculate for.
 pub type UiAmountToAmount<'account, 'amount> =
-    ui_amount_to_amount::UiAmountToAmount<'account, 'amount, Program>;
+    ui_amount_to_amount::UiAmountToAmount<'account, 'amount, TokenProgram>;
 
 /// Transfer lamports from a native SOL account to a destination account.
 ///
@@ -493,7 +495,7 @@ pub type UiAmountToAmount<'account, 'amount> =
 ///   2. `[]` The source account's multisignature owner/delegate.
 ///   3. `..+M` `[signer]` M signer accounts.
 pub type UnwrapLamports<'account, 'multisig, MultisigSigner> =
-    unwrap_lamports::UnwrapLamports<'account, 'multisig, MultisigSigner, Program>;
+    unwrap_lamports::UnwrapLamports<'account, 'multisig, MultisigSigner, TokenProgram>;
 
 /// This instruction is to be used to rescue SOL sent to any `TokenProgram`
 /// owned account by sending them to any other account, leaving behind only
@@ -512,7 +514,12 @@ pub type UnwrapLamports<'account, 'multisig, MultisigSigner> =
 ///   2. `[]` The source account's multisignature owner/delegate.
 ///   3. `..+M` `[signer]` M signer accounts.
 pub type WithdrawExcessLamports<'account, 'multisig, MultisigSigner> =
-    withdraw_excess_lamports::WithdrawExcessLamports<'account, 'multisig, MultisigSigner, Program>;
+    withdraw_excess_lamports::WithdrawExcessLamports<
+        'account,
+        'multisig,
+        MultisigSigner,
+        TokenProgram,
+    >;
 
 #[cold]
 fn account_borrow_failed_error() -> ProgramError {

--- a/programs/token/src/instructions/revoke.rs
+++ b/programs/token/src/instructions/revoke.rs
@@ -132,7 +132,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -149,7 +149,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/revoke.rs
+++ b/programs/token/src/instructions/revoke.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -43,7 +43,8 @@ const DATA_LEN: usize = 1;
 ///   0. `[writable]` The source account.
 ///   1. `[]` The source account's multisignature owner/delegate.
 ///   2. `..+M` `[signer]` M signer accounts.
-pub struct Revoke<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram> {
+pub struct Revoke<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
+{
     /// The source account.
     pub source: &'account AccountView,
 
@@ -57,7 +58,7 @@ pub struct Revoke<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Progr
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> Revoke<'account, '_, &'account AccountView, Program> {
+impl<'account, Program: TokenInterface> Revoke<'account, '_, &'account AccountView, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -74,7 +75,7 @@ impl<'account, Program: TokenProgram> Revoke<'account, '_, &'account AccountView
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     Revoke<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `Revoke` instruction with a
@@ -190,7 +191,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for Revoke<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -221,7 +222,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for Revoke<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/set_authority.rs
+++ b/programs/token/src/instructions/set_authority.rs
@@ -170,7 +170,7 @@ impl<
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -187,7 +187,7 @@ impl<
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/set_authority.rs
+++ b/programs/token/src/instructions/set_authority.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, write_bytes, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -59,7 +59,7 @@ pub struct SetAuthority<
     'address,
     'multisig,
     MultisigSigner: AsRef<AccountView>,
-    Program: TokenProgram,
+    Program: TokenInterface,
 > {
     /// The mint or account to change the authority of.
     pub account: &'account AccountView,
@@ -80,7 +80,7 @@ pub struct SetAuthority<
     _program: PhantomData<Program>,
 }
 
-impl<'account, 'address, Program: TokenProgram>
+impl<'account, 'address, Program: TokenInterface>
     SetAuthority<'account, 'address, '_, &'account AccountView, Program>
 {
     /// The instruction discriminator.
@@ -104,8 +104,13 @@ impl<'account, 'address, Program: TokenProgram>
     }
 }
 
-impl<'account, 'address, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
-    SetAuthority<'account, 'address, 'multisig, MultisigSigner, Program>
+impl<
+        'account,
+        'address,
+        'multisig,
+        MultisigSigner: AsRef<AccountView>,
+        Program: TokenInterface,
+    > SetAuthority<'account, 'address, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `SetAuthority` instruction with a
     /// multisignature authority and signer accounts.
@@ -224,7 +229,7 @@ impl<'account, 'address, 'multisig, MultisigSigner: AsRef<AccountView>, Program:
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for SetAuthority<'_, '_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -265,7 +270,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for SetAuthority<'_, '_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/sync_native.rs
+++ b/programs/token/src/instructions/sync_native.rs
@@ -98,7 +98,7 @@ impl<'account, Program: TokenInterface> SyncNative<'account, Program> {
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/sync_native.rs
+++ b/programs/token/src/instructions/sync_native.rs
@@ -4,7 +4,7 @@ use {
             account_borrow_failed_error, invalid_argument_error, CpiWriter, UNINIT_BYTE,
             UNINIT_CPI_ACCOUNT, UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -45,7 +45,7 @@ const DATA_LEN: usize = 1;
 ///   0. `[writable]` The native token account to sync with its underlying
 ///      lamports.
 ///   1. `[]` Rent sysvar.
-pub struct SyncNative<'account, Program: TokenProgram> {
+pub struct SyncNative<'account, Program: TokenInterface> {
     /// Native Token Account
     pub native_token: &'account AccountView,
 
@@ -55,7 +55,7 @@ pub struct SyncNative<'account, Program: TokenProgram> {
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> SyncNative<'account, Program> {
+impl<'account, Program: TokenInterface> SyncNative<'account, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -131,7 +131,7 @@ impl<'account, Program: TokenProgram> SyncNative<'account, Program> {
     }
 }
 
-impl<Program: TokenProgram> CpiWriter for SyncNative<'_, Program> {
+impl<Program: TokenInterface> CpiWriter for SyncNative<'_, Program> {
     #[inline(always)]
     fn write_accounts<'cpi>(
         &self,
@@ -160,7 +160,7 @@ impl<Program: TokenProgram> CpiWriter for SyncNative<'_, Program> {
     }
 }
 
-impl<Program: TokenProgram> super::batch::IntoBatch<Program> for SyncNative<'_, Program> {
+impl<Program: TokenInterface> super::batch::IntoBatch<Program> for SyncNative<'_, Program> {
     #[inline(always)]
     fn into_batch<'account, 'state>(
         self,

--- a/programs/token/src/instructions/thaw_account.rs
+++ b/programs/token/src/instructions/thaw_account.rs
@@ -147,7 +147,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -164,7 +164,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/thaw_account.rs
+++ b/programs/token/src/instructions/thaw_account.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -49,7 +49,7 @@ pub struct ThawAccount<
     'account,
     'multisig,
     MultisigSigner: AsRef<AccountView>,
-    Program: TokenProgram,
+    Program: TokenInterface,
 > {
     ///  The account to thaw.
     pub account: &'account AccountView,
@@ -67,7 +67,7 @@ pub struct ThawAccount<
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> ThawAccount<'account, '_, &'account AccountView, Program> {
+impl<'account, Program: TokenInterface> ThawAccount<'account, '_, &'account AccountView, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -88,7 +88,7 @@ impl<'account, Program: TokenProgram> ThawAccount<'account, '_, &'account Accoun
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     ThawAccount<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `ThawAccount` instruction with a
@@ -206,7 +206,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for ThawAccount<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -249,7 +249,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for ThawAccount<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/transfer.rs
+++ b/programs/token/src/instructions/transfer.rs
@@ -158,7 +158,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -175,7 +175,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/transfer.rs
+++ b/programs/token/src/instructions/transfer.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, write_bytes, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -49,8 +49,12 @@ const DATA_LEN: usize = 9;
 ///   1. `[writable]` The destination account.
 ///   2. `[]` The source account's multisignature owner/delegate.
 ///   3. `..+M` `[signer]` M signer accounts.
-pub struct Transfer<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
-{
+pub struct Transfer<
+    'account,
+    'multisig,
+    MultisigSigner: AsRef<AccountView>,
+    Program: TokenInterface,
+> {
     /// The source account.
     pub from: &'account AccountView,
 
@@ -70,7 +74,7 @@ pub struct Transfer<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Pro
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> Transfer<'account, '_, &'account AccountView, Program> {
+impl<'account, Program: TokenInterface> Transfer<'account, '_, &'account AccountView, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -93,7 +97,7 @@ impl<'account, Program: TokenProgram> Transfer<'account, '_, &'account AccountVi
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     Transfer<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `Transfer` instruction with a
@@ -213,7 +217,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for Transfer<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -256,7 +260,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for Transfer<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/transfer_checked.rs
+++ b/programs/token/src/instructions/transfer_checked.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, write_bytes, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -60,7 +60,7 @@ pub struct TransferChecked<
     'account,
     'multisig,
     MultisigSigner: AsRef<AccountView>,
-    Program: TokenProgram,
+    Program: TokenInterface,
 > {
     /// The source account.
     pub from: &'account AccountView,
@@ -87,7 +87,7 @@ pub struct TransferChecked<
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram>
+impl<'account, Program: TokenInterface>
     TransferChecked<'account, '_, &'account AccountView, Program>
 {
     /// The instruction discriminator.
@@ -114,7 +114,7 @@ impl<'account, Program: TokenProgram>
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     TransferChecked<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `TransferChecked` instruction with a
@@ -238,7 +238,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for TransferChecked<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -283,7 +283,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for TransferChecked<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/transfer_checked.rs
+++ b/programs/token/src/instructions/transfer_checked.rs
@@ -179,7 +179,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -196,7 +196,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/ui_amount_to_amount.rs
+++ b/programs/token/src/instructions/ui_amount_to_amount.rs
@@ -4,7 +4,7 @@ use {
             invalid_argument_error, write_bytes, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -37,7 +37,7 @@ const MAX_DATA_LEN: usize = 255;
 /// Accounts expected by this instruction:
 ///
 ///   0. `[]` The mint to calculate for.
-pub struct UiAmountToAmount<'account, 'amount, Program: TokenProgram> {
+pub struct UiAmountToAmount<'account, 'amount, Program: TokenInterface> {
     /// The mint to calculate for.
     pub mint: &'account AccountView,
 
@@ -48,7 +48,7 @@ pub struct UiAmountToAmount<'account, 'amount, Program: TokenProgram> {
     _program: PhantomData<Program>,
 }
 
-impl<'account, 'amount, Program: TokenProgram> UiAmountToAmount<'account, 'amount, Program> {
+impl<'account, 'amount, Program: TokenInterface> UiAmountToAmount<'account, 'amount, Program> {
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -121,7 +121,9 @@ impl<'account, 'amount, Program: TokenProgram> UiAmountToAmount<'account, 'amoun
     }
 }
 
-impl<Program: TokenProgram> super::batch::IntoBatch<Program> for UiAmountToAmount<'_, '_, Program> {
+impl<Program: TokenInterface> super::batch::IntoBatch<Program>
+    for UiAmountToAmount<'_, '_, Program>
+{
     #[inline(always)]
     fn into_batch<'account, 'state>(
         self,
@@ -138,7 +140,7 @@ impl<Program: TokenProgram> super::batch::IntoBatch<Program> for UiAmountToAmoun
     }
 }
 
-impl<Program: TokenProgram> CpiWriter for UiAmountToAmount<'_, '_, Program> {
+impl<Program: TokenInterface> CpiWriter for UiAmountToAmount<'_, '_, Program> {
     #[inline(always)]
     fn write_accounts<'cpi>(
         &self,

--- a/programs/token/src/instructions/ui_amount_to_amount.rs
+++ b/programs/token/src/instructions/ui_amount_to_amount.rs
@@ -88,7 +88,7 @@ impl<'account, 'amount, Program: TokenInterface> UiAmountToAmount<'account, 'amo
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/unwrap_lamports.rs
+++ b/programs/token/src/instructions/unwrap_lamports.rs
@@ -174,7 +174,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -191,7 +191,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/instructions/unwrap_lamports.rs
+++ b/programs/token/src/instructions/unwrap_lamports.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, write_bytes, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -67,7 +67,7 @@ pub struct UnwrapLamports<
     'account,
     'multisig,
     MultisigSigner: AsRef<AccountView>,
-    Program: TokenProgram,
+    Program: TokenInterface,
 > {
     /// The source account.
     pub source: &'account AccountView,
@@ -88,7 +88,9 @@ pub struct UnwrapLamports<
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram> UnwrapLamports<'account, '_, &'account AccountView, Program> {
+impl<'account, Program: TokenInterface>
+    UnwrapLamports<'account, '_, &'account AccountView, Program>
+{
     /// The instruction discriminator.
     pub const DISCRIMINATOR: u8 = DISCRIMINATOR;
 
@@ -111,7 +113,7 @@ impl<'account, Program: TokenProgram> UnwrapLamports<'account, '_, &'account Acc
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     UnwrapLamports<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `UnwrapLamports` instruction with a
@@ -231,7 +233,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for UnwrapLamports<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -274,7 +276,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for UnwrapLamports<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/withdraw_excess_lamports.rs
+++ b/programs/token/src/instructions/withdraw_excess_lamports.rs
@@ -5,7 +5,7 @@ use {
             invalid_argument_error, CpiWriter, UNINIT_BYTE, UNINIT_CPI_ACCOUNT,
             UNINIT_INSTRUCTION_ACCOUNT,
         },
-        TokenProgram,
+        TokenInterface,
     },
     core::{marker::PhantomData, mem::MaybeUninit, slice::from_raw_parts},
     solana_account_view::AccountView,
@@ -51,7 +51,7 @@ pub struct WithdrawExcessLamports<
     'account,
     'multisig,
     MultisigSigner: AsRef<AccountView>,
-    Program: TokenProgram,
+    Program: TokenInterface,
 > {
     /// Source Account owned by the token program.
     pub source: &'account AccountView,
@@ -69,7 +69,7 @@ pub struct WithdrawExcessLamports<
     _program: PhantomData<Program>,
 }
 
-impl<'account, Program: TokenProgram>
+impl<'account, Program: TokenInterface>
     WithdrawExcessLamports<'account, '_, &'account AccountView, Program>
 {
     /// The instruction discriminator.
@@ -93,7 +93,7 @@ impl<'account, Program: TokenProgram>
     }
 }
 
-impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProgram>
+impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInterface>
     WithdrawExcessLamports<'account, 'multisig, MultisigSigner, Program>
 {
     /// Creates a new `WithdrawExcessLamports` instruction with a
@@ -211,7 +211,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenProg
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> CpiWriter
     for WithdrawExcessLamports<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]
@@ -254,7 +254,7 @@ impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> CpiWriter
     }
 }
 
-impl<MultisigSigner: AsRef<AccountView>, Program: TokenProgram> super::batch::IntoBatch<Program>
+impl<MultisigSigner: AsRef<AccountView>, Program: TokenInterface> super::batch::IntoBatch<Program>
     for WithdrawExcessLamports<'_, '_, MultisigSigner, Program>
 {
     #[inline(always)]

--- a/programs/token/src/instructions/withdraw_excess_lamports.rs
+++ b/programs/token/src/instructions/withdraw_excess_lamports.rs
@@ -152,7 +152,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]
@@ -169,7 +169,7 @@ impl<'account, 'multisig, MultisigSigner: AsRef<AccountView>, Program: TokenInte
     /// # Important
     ///
     /// This method does not verify that `program` satisfies
-    /// [`TokenProgram::verify`]. The caller must ensure the program address
+    /// [`TokenInterface::verify`]. The caller must ensure the program address
     /// has already been checked and corresponds to the expected
     /// token program.
     #[inline(always)]

--- a/programs/token/src/lib.rs
+++ b/programs/token/src/lib.rs
@@ -14,7 +14,7 @@ solana_address::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
 /// A trait for token programs that can be used in a CPI with a statically known
 /// program address.
-pub trait TokenProgram {
+pub trait TokenInterface {
     const ID: Address;
 
     /// Returns `Ok(())` when `address` is accepted for cross-program
@@ -36,9 +36,9 @@ pub trait TokenProgram {
 ///
 /// This struct implements the `TokenProgram` trait, which statically provides
 /// the SPL Token address for instruction building.
-pub struct Program;
+pub struct TokenProgram;
 
-impl TokenProgram for Program {
+impl TokenInterface for TokenProgram {
     const ID: Address = crate::ID;
 }
 


### PR DESCRIPTION
### Problem

PR #428 introduced the `TokenProgram` generic trait for token programs, but the name is a bit awkward.

### Solution

As suggested in https://github.com/anza-xyz/pinocchio/pull/431#discussion_r3560773980, rename the trait to `TokenInterface` so Token and Token-2022 can implement the trait on structs named `TokenProgram` and `Token2022Program`.