### PR TITLE
programs/token: Allow token-2022 on token helpers

### DIFF
--- a/programs/token-2022/src/lib.rs
+++ b/programs/token-2022/src/lib.rs
@@ -3,12 +3,7 @@
 pub mod instructions;
 pub mod state;
 
-use {
-    core::mem::MaybeUninit,
-    pinocchio_token::TokenInterface,
-    solana_address::Address,
-    solana_program_error::{ProgramError, ProgramResult},
-};
+use {core::mem::MaybeUninit, pinocchio_token::TokenInterface, solana_address::Address};
 
 solana_address::declare_id!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 
@@ -22,23 +17,6 @@ pub struct Token2022Program;
 
 impl TokenInterface for Token2022Program {
     const ID: Address = crate::ID;
-
-    #[inline(always)]
-    fn verify(address: &Address) -> ProgramResult {
-        if address != &Self::ID && address != &pinocchio_token::ID {
-            return Err(incorrect_program_id());
-        }
-
-        Ok(())
-    }
-}
-
-/// Cold helper for constructing `ProgramError::IncorrectProgramId` outside the
-/// hot path.
-#[doc(hidden)]
-#[cold]
-fn incorrect_program_id() -> ProgramError {
-    ProgramError::IncorrectProgramId
 }
 
 #[inline(always)]

--- a/programs/token/src/lib.rs
+++ b/programs/token/src/lib.rs
@@ -12,6 +12,9 @@ pub mod state;
 
 solana_address::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
+/// The address of the SPL Token-2022 program.
+const TOKEN_2022: Address = Address::from_str_const("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+
 /// A trait for token programs that can be used in a CPI with a statically known
 /// program address.
 pub trait TokenInterface {
@@ -40,6 +43,20 @@ pub struct TokenProgram;
 
 impl TokenInterface for TokenProgram {
     const ID: Address = crate::ID;
+
+    /// Returns `Ok(())` when `address` is accepted for cross-program
+    /// invocations.
+    ///
+    /// This implementation accepts both SPL Token and the SPL Token-2022
+    /// programs.
+    #[inline(always)]
+    fn verify(address: &Address) -> ProgramResult {
+        if address != &Self::ID && address != &TOKEN_2022 {
+            return Err(incorrect_program_id());
+        }
+
+        Ok(())
+    }
 }
 
 /// Cold helper for constructing `ProgramError::IncorrectProgramId` outside the


### PR DESCRIPTION
### Problem

Currently, helpers using the `TokenProgram` generic type do not accept Token-2022, but Token-2022 accepts Token. This is not ideal since Token-2022 has a superset of token instructions.

### Solution

Switch the implementation to allow Token-2022 on `TokenProgram` genetic type, which `Token2022Program` generic type only accepts Token-2022.