### PR TITLE
ci: fix caching in publishing + properly validate inputs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,6 +14,10 @@ inputs:
   solana:
     description: Install Solana if `true`. Defaults to `false`.
     required: false
+  cache:
+    description: Enable dependency caching if `true`. Defaults to `true`.
+    required: false
+    default: true
 
 runs:
   using: 'composite'
@@ -25,7 +29,7 @@ runs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
       with:
         node-version: 20
-        cache: 'pnpm'
+        cache: ${{ inputs.cache == 'true' && 'pnpm' || '' }}
 
     - name: Install Dependencies
       run: pnpm install --frozen-lockfile
@@ -74,7 +78,7 @@ runs:
       uses: solana-program/actions/install-solana@678f622be092844a943327c17430401d871e6998  # v1
       with:
         version: ${{ env.SOLANA_VERSION }}
-        cache: true
+        cache: ${{ inputs.cache }}
 
     - name: Install 'cargo-audit'
       if: ${{ contains(inputs.components, 'audit') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,21 +59,25 @@ jobs:
           components: release, semver-checks
 
       - name: Set Version
+        env:
+          CRATE: ${{ inputs.crate }}
+          LEVEL: ${{ inputs.level }}
+          VERSION: ${{ inputs.version }}
         run: |
-          if [ "${{ inputs.level }}" == "version" ]; then
-            LEVEL=${{ inputs.version }}
-          else
-            LEVEL=${{ inputs.level }}
+          if [ "$LEVEL" == "version" ]; then
+            LEVEL="$VERSION"
           fi
 
           git config --global user.email "github-actions@github.com"
           git config --global user.name "github-actions"
 
-          cargo release $LEVEL --manifest-path ${{ inputs.crate }}/Cargo.toml --no-tag --no-publish --no-push --no-confirm --execute
+          cargo release "$LEVEL" --manifest-path "$CRATE/Cargo.toml" --no-tag --no-publish --no-push --no-confirm --execute
 
       - name: Check semver
+        env:
+          CRATE: ${{ inputs.crate }}
         run: |
-          pnpm semver ${{ inputs.crate }}
+          pnpm semver "$CRATE"
 
       - name: Summary
         run: |
@@ -119,10 +123,14 @@ jobs:
           solana: true
 
       - name: Build
-        run: pnpm build-sbf ${{ inputs.crate }}
+        env:
+          CRATE: ${{ inputs.crate }}
+        run: pnpm build-sbf "$CRATE"
 
       - name: Test
-        run: pnpm test ${{ inputs.crate }}
+        env:
+          CRATE: ${{ inputs.crate }}
+        run: pnpm test "$CRATE"
 
       - name: Set Git Author
         if: github.event.inputs.dry_run != 'true'
@@ -142,20 +150,22 @@ jobs:
         id: publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          CRATE: ${{ inputs.crate }}
+          LEVEL: ${{ inputs.level }}
+          VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [ "${{ inputs.level }}" == "version" ]; then
-            LEVEL=${{ inputs.version }}
-          else
-            LEVEL=${{ inputs.level }}
+          if [ "$LEVEL" == "version" ]; then
+            LEVEL="$VERSION"
           fi
 
-          if [ "${{ inputs.dry_run }}" == "true" ]; then
+          if [ "$DRY_RUN" == "true" ]; then
             OPTIONS="--dry-run"
           else
             OPTIONS=""
           fi
 
-          pnpm tsx ./scripts/publish.mts ${{ inputs.crate }} $LEVEL $OPTIONS
+          pnpm tsx ./scripts/publish.mts "$CRATE" "$LEVEL" $OPTIONS
 
       - name: Generate a changelog
         if: github.event.inputs.dry_run != 'true' && github.event.inputs.create_release == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           toolchain: test
           components: release, semver-checks
+          cache: false
 
       - name: Set Version
         env:
@@ -121,6 +122,7 @@ jobs:
           toolchain: test
           components: release
           solana: true
+          cache: false
 
       - name: Build
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,9 +44,6 @@ on:
         type: boolean
         default: true
 
-env:
-  CACHE: true
-
 jobs:
   semver_check:
     name: Check Semver
@@ -58,7 +55,6 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          cargo-cache-key: cargo-semver-checks
           toolchain: test
           components: release, semver-checks
 
@@ -118,7 +114,6 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          cargo-cache-key: cargo-publish
           toolchain: test
           components: release
           solana: true


### PR DESCRIPTION
Two changes to the release/publish flow.

**Drop caching in the publish flow.** The `publish_release` job runs in either the `dry-run` (unprotected) or `prod` (reviewer-gated) environment, but both shared the same caches, and cache keys aren't scoped per environment. Added a `cache` input to the setup action (defaults on, so CI is unchanged) and set `cache: false` on both publish setup steps.

**Pass inputs via env vars.** The free-form `version` input was interpolated unquoted into `run:` scripts, allowing shell injection. Inputs are now bound to step `env:` and used as quoted shell variables.

shotout to @hosoludi for reporting this