### PR TITLE
programs/token: Bump crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "pinocchio-token"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "solana-account-view",
  "solana-address",

--- a/programs/token/Cargo.toml
+++ b/programs/token/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pinocchio-token"
 description = "Pinocchio helpers to invoke Token program instructions"
-version = "0.6.0"
+version = "0.7.0"
 edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"


### PR DESCRIPTION
### Problem

A new crate version was published but the workflow [failed](https://github.com/anza-xyz/pinocchio/actions/runs/30457459141/job/90594805630) to commit the version bump to `Cargo.toml`.

### Solution

Manually bump the crate version.