### PR TITLE
ci: Add dependent version option on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,17 @@ on:
         description: Version (used with level "version")
         required: false
         type: string
+      dependent_version:
+        description: |
+          How workspace dependencies should be handled.
+          - "fix": (Default) Only bumps the workspace for semver-breakage - prefer this option
+          - "upgrade": Bumps workspace version regardless - only use if another SDK crate requires new code
+        required: true
+        default: fix
+        type: choice
+        options:
+          - fix
+          - upgrade
       dry_run:
         description: Dry run
         required: true
@@ -167,7 +178,7 @@ jobs:
             OPTIONS=""
           fi
 
-          pnpm tsx ./scripts/publish.mts "$CRATE" "$LEVEL" $OPTIONS
+          pnpm tsx ./scripts/publish.mts "$CRATE" "$LEVEL" "${{ inputs.dependent_version }}" $OPTIONS
 
       - name: Generate a changelog
         if: github.event.inputs.dry_run != 'true' && github.event.inputs.create_release == 'true'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ repository = "https://github.com/anza-xyz/pinocchio"
 rust-version = "1.89.0"
 
 [workspace.dependencies]
-pinocchio = { path = "sdk", default-features = false }
-pinocchio-token = { path = "programs/token" }
+pinocchio = { version = "0.11.0", path = "sdk", default-features = false }
+pinocchio-token = { version = "0.7.0", path = "programs/token" }
 solana-account-view = "2.0"
 solana-address = "2.0"
 solana-define-syscall = "5.0"

--- a/scripts/publish.mts
+++ b/scripts/publish.mts
@@ -13,9 +13,14 @@ const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
 const fix = popArgument(args, '--dry-run');
 const dryRun = argv['dry-run'] ?? false;
 
-const [level] = args;
+const [level, dependentVersion] = args;
+
 if (!level) {
   throw new Error('A version level — e.g. "patch" — must be provided.');
+}
+
+if (!['fix', 'upgrade'].includes(dependentVersion)) {
+  throw new Error('Dependent version must be "fix" or "upgrade".');
 }
 
 // Get the package information from the crate TOML file.
@@ -28,8 +33,15 @@ cd(path.dirname(manifestPath));
 
 // Publish the new version.
 const releaseArgs = dryRun
-  ? []
-  : ['--tag-name', `${name}@v{{version}}`, '--no-confirm', '--execute'];
+  ? ['--dependent-version', dependentVersion]
+  : [
+    '--tag-name',
+    `${name}@v{{version}}`,
+    '--no-confirm',
+    '--execute',
+    '--dependent-version',
+    dependentVersion,
+  ];
 await $`cargo release ${level} ${releaseArgs}`;
 
 // Stop here if this is a dry run.


### PR DESCRIPTION
### Problem

Trying to publish a crate with a dependency to another crate of the workspace currently [fails](https://github.com/anza-xyz/pinocchio/actions/runs/30660798776/job/91256457595) since it is required to specify the version – the workspace `Cargo.toml` does not include a version.

### Solution

Include a version to all workspace dependencies and update the publish workflow to include the "dependent version" option to decide how they should be updated.